### PR TITLE
fix(pricing): sync Grok rates to xAI's published rate (blockrun#503)

### DIFF
--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -107,9 +107,9 @@ export const MODEL_PRICING: Record<string, { input: number; output: number; perC
   'google/gemini-2.5-pro': { input: 1.25, output: 10.0 },
   'google/gemini-3.1-pro': { input: 2.0, output: 12.0 },
   // xAI
-  'xai/grok-4.3': { input: 1.5, output: 4.0 },        // 1M ctx; demoted from flagship 2026-07-14
-  'xai/grok-4.5': { input: 2.5, output: 9.0 },        // xAI flagship — 500K ctx (note: less than 4.3's 1M)
-  'xai/grok-build-0.1': { input: 1.5, output: 3.0 },  // agentic coding, OpenRouter resale
+  'xai/grok-4.3': { input: 1.25, output: 2.5 },        // 1M ctx; demoted from flagship 2026-07-14
+  'xai/grok-4.5': { input: 2.0, output: 6.0 },        // xAI flagship — 500K ctx (note: less than 4.3's 1M)
+  'xai/grok-build-0.1': { input: 1.0, output: 2.0 },  // agentic coding, OpenRouter resale
   // DeepSeek (gateway re-aliased these to V4 Flash on 2026-05-03; price cut
   // again upstream 2026-08-07 to $0.14/$0.28 — mirrored here 2026-08-12).
   'deepseek/deepseek-chat': { input: 0.14, output: 0.28 },

--- a/src/ui/model-picker.ts
+++ b/src/ui/model-picker.ts
@@ -391,7 +391,7 @@ export const PICKER_CATEGORIES: ModelCategory[] = [
       // superseded sibling listed directly under its successor is choice
       // paralysis, not choice. `gemini-2.5` still resolves to it.
       { id: 'google/gemini-3.1-pro',       shortcut: 'gemini',    label: 'Gemini 3.1 Pro',    price: '$2/$12' },
-      { id: 'xai/grok-4.5',                shortcut: 'grok',      label: 'Grok 4.5',          price: '$2.5/$9' },
+      { id: 'xai/grok-4.5',                shortcut: 'grok',      label: 'Grok 4.5',          price: '$2/$6' },
       // Kimi K3 (2026-07): 2.8T open MoE, 1M context, multimodal + reasoning.
       // Replaced the budget K2.7 line — now premium-priced ($3/$15).
       { id: 'moonshot/kimi-k3',            shortcut: 'kimi',      label: 'Kimi K3',           price: '$3/$15' },


### PR DESCRIPTION
Follow-on to blockrun#503 (live in production since 2026-09-04).

**This one is not a docs fix.** The values changed here are the executable price table this client uses to estimate and display cost, so stale entries here mis-state what a call will cost — not just what a README says.

Six Grok SKUs on the gateway carried a resale spread over xAI's published rate — up to +140% on output — while the site claimed "provider list price on chat tokens, no markup". The prices were moved rather than the claim:

| SKU | was | now |
|---|---|---|
| `xai/grok-4.3` | $1.50 / $4.00 | **$1.25 / $2.50** |
| `xai/grok-4.5` | $2.50 / $9.00 | **$2.00 / $6.00** |
| `xai/grok-build-0.1` | $1.50 / $3.00 | **$1.00 / $2.00** |

Verified against `docs.x.ai/docs/models`; the blockrun-sol agent independently re-checked all 24 numbers (both axes, both tiers) against OpenRouter's live endpoint list.

No price guard reaches this repo — `brand/consumers.json` lists 15 repos and the gateway's drift sweep covers its own sheets only. Found by grep, not by CI.

**CHANGELOG entries are deliberately unchanged.** A dated entry records what the price was on that day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChUparsmmkz1GJrvzqmuvL