### PR TITLE
feat: add account API billing across Franklin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Franklin Agent
 
-Open-source AI agent with a wallet. <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models. Pay per use with USDC via x402.
+Open-source AI agent with a wallet. <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models. Account API keys or pay per use with USDC via x402 on Solana and Base.
 
 ## Commands
 
@@ -15,6 +15,7 @@ npm start                # launch agent
 
 ```
 src/
+├── payments/account.ts  # Shared account auth for direct gateway calls
 ├── index.ts             # CLI entry point
 ├── agent/               # Agent loop and orchestration
 ├── commands/            # Built-in agent commands

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 
 ## The pitch in one paragraph
 
-Franklin Agent is an **autonomous economic agent** — an AI that holds a USDC wallet and spends it to get real work done, with **trading as its flagship arena**. It buys live market data, proposes trade plans you approve before a cent moves, pursues long-running goals across sessions, keeps a wallet-bound trading journal, and picks the best model per task from 55+ providers. You state an outcome and set a budget. Franklin Agent decides what to call, what to pay for, and when to stop. Every paid action routes through the [x402](https://x402.org) micropayment protocol and settles against your own wallet. No subscriptions. No API keys. No account. The wallet is the identity.
+Franklin Agent is an **autonomous economic agent** — an AI that holds a USDC wallet and spends it to get real work done, with **trading as its flagship arena**. It buys live market data, proposes trade plans you approve before a cent moves, pursues long-running goals across sessions, keeps a wallet-bound trading journal, and picks the best model per task from 55+ providers. You state an outcome and set a budget. Franklin Agent decides what to call, what to pay for, and when to stop. Access models, media, search and data with a BlockRun account API key, or use [x402](https://x402.org) USDC payments on Solana or Base. Actual on-chain trades still use your transaction wallet.
 
 Built by the [BlockRun](https://blockrun.ai) team. Apache-2.0. TypeScript. Ships as one npm package.
 
@@ -55,6 +55,32 @@ Built by the [BlockRun](https://blockrun.ai) team. Apache-2.0. TypeScript. Ships
 > in USDC. No monthly fees. No rate limits. No overdraft.
 
 ---
+
+## Account API key
+
+Register at [user.blockrun.ai](https://user.blockrun.ai), create an
+[API key](https://user.blockrun.ai/dashboard/keys), and add
+[credits](https://user.blockrun.ai/dashboard/credits).
+
+```bash
+export BLOCKRUN_API_KEY="brk_live_..."
+franklin start
+# Or: franklin proxy / franklin serve
+```
+
+The account endpoint defaults to `https://api.blockrun.ai/v1`; optionally set
+`BLOCKRUN_API_BASE_URL`. API mode covers the agent and its subagents, proxy,
+media generation/polling, search and gateway data tools. It does not create a
+payment wallet. `franklin balance`, the Wallet tool, and desktop/panel account
+status point to the account portal. Keys are never returned by status endpoints.
+HTTP 402 asks you to top up account credits and never switches to wallet payment.
+
+Local cost totals and `--max-spend` use estimates in API mode; account usage in
+the portal is authoritative. Wallet-signed cloud sync and wallet-owned asset
+listings require wallet mode; local sessions remain available. Trading and
+marketplace wallet signatures still require a separate transaction wallet.
+Unset `BLOCKRUN_API_KEY` to return to wallet billing. New wallet users default
+to Solana; existing chain choices and Base-only wallets are preserved.
 
 ## Quick start
 
@@ -352,7 +378,7 @@ No single model is best at everything. Sonnet writes better code, Gemini handles
 
 ### 🔐 &nbsp;Wallet is identity
 
-No email. No phone. No KYC. Your Base or Solana address is your account — portable, permissionless, global. API keys require US banking and account approval. A wallet requires only USDC.
+Choose an account API key, or wallet authentication on Solana or Base. Register and create account keys at [user.blockrun.ai](https://user.blockrun.ai).
 
 </td>
 </tr>
@@ -467,7 +493,7 @@ Core is workflow-agnostic. Add new verticals without touching the loop. Discover
 │  <!-- br:models.chatVisible@live -->76<!-- /br:models.chatVisible@live --> LLMs · CoinGecko · Search · Image APIs · paid services  │
 ├──────────────────────────────────────────────────────────────┤
 │  x402 Micropayment Protocol                                  │
-│  HTTP 402 · USDC on Base & Solana · signed payment payloads  │
+│  HTTP 402 · USDC on Solana & Base · signed payment payloads  │
 └──────────────────────────────────────────────────────────────┘
                             │
                             ▼
@@ -509,7 +535,7 @@ src/
 ├── ui/                Ink-based terminal UI
 ├── proxy/             Payment proxy for external tools
 ├── router/            Learned model router (<!-- br:models.chatVisible@live -->76<!-- /br:models.chatVisible@live --> models, Elo scoring)
-├── wallet/            Wallet management (Base + Solana)
+├── wallet/            Wallet management (Solana + Base)
 ├── mcp/               MCP server auto-discovery
 └── commands/          CLI subcommands
 ```

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 <br><br>
 
 <h1>Franklin Agent</h1>
-<h3>The AI agent with a wallet.</h3>
+<h3>The AI agent with a budget.</h3>
 
 <p>
-  Other agents just talk. Franklin Agent holds your USDC <em>and puts it to work</em> —<br>
+  Franklin Agent uses account credits or your USDC wallet to get work done —<br>
   trading, research, and autonomous tasks with real budgets, real guardrails, real outcomes.<br>
-  One wallet. Every model. Every paid API. Pay only for outcomes — not subscriptions.
+  One interface for models and paid APIs. Pay for usage as you go.
 </p>
 
 <p>
@@ -44,19 +44,30 @@
 
 ## The pitch in one paragraph
 
-Franklin Agent is an **autonomous economic agent** — an AI that holds a USDC wallet and spends it to get real work done, with **trading as its flagship arena**. It buys live market data, proposes trade plans you approve before a cent moves, pursues long-running goals across sessions, keeps a wallet-bound trading journal, and picks the best model per task from 55+ providers. You state an outcome and set a budget. Franklin Agent decides what to call, what to pay for, and when to stop. Access models, media, search and data with a BlockRun account API key, or use [x402](https://x402.org) USDC payments on Solana or Base. Actual on-chain trades still use your transaction wallet.
+Franklin Agent is an **autonomous economic agent** — an AI that uses account credits or a USDC wallet to get real work done, with **trading as its flagship arena**. It buys live market data, proposes trade plans you approve before a cent moves, pursues long-running goals across sessions, keeps a wallet-bound trading journal, and picks the best model per task from 55+ providers. You state an outcome and set a budget. Franklin Agent decides what to call, what to pay for, and when to stop. Access models, media, search and data with a BlockRun account API key, or use [x402](https://x402.org) USDC payments on Solana or Base. Actual on-chain trades still use your transaction wallet.
 
 Built by the [BlockRun](https://blockrun.ai) team. Apache-2.0. TypeScript. Ships as one npm package.
 
 > **YOPO — You Only Pay Outcome**
 >
-> Not a subscription (pay for access). Not a generic pay-per-call (pay for trying).
-> You pay only for the work Franklin Agent delivers. Provider cost + 5%, settled per action
-> in USDC. No monthly fees. No rate limits. No overdraft.
+> Model and tool calls are billed by usage through account credits or x402 USDC payments.
+> Rates depend on the service and your account. Account credit limits, provider limits,
+> and rate limits apply; completing your overall task is not a billing guarantee.
 
 ---
 
 ## Account API key
+
+Until this integration is released on npm, build the API-enabled source checkout:
+
+```bash
+npm ci
+npm run build
+export BLOCKRUN_API_KEY="brk_live_..."
+node dist/index.js start
+```
+
+Use the CLI command below after installing a release containing this integration.
 
 Register at [user.blockrun.ai](https://user.blockrun.ai), create an
 [API key](https://user.blockrun.ai/dashboard/keys), and add
@@ -70,7 +81,7 @@ franklin start
 
 The account endpoint defaults to `https://api.blockrun.ai/v1`; optionally set
 `BLOCKRUN_API_BASE_URL`. API mode covers the agent and its subagents, proxy,
-media generation/polling, search and gateway data tools. It does not create a
+media generation/polling, search and gateway data tools, subject to gateway availability. It does not create a
 payment wallet. `franklin balance`, the Wallet tool, and desktop/panel account
 status point to the account portal. Keys are never returned by status endpoints.
 HTTP 402 asks you to top up account credits and never switches to wallet payment.
@@ -79,10 +90,12 @@ Local cost totals and `--max-spend` use estimates in API mode; account usage in
 the portal is authoritative. Wallet-signed cloud sync and wallet-owned asset
 listings require wallet mode; local sessions remain available. Trading and
 marketplace wallet signatures still require a separate transaction wallet.
-Unset `BLOCKRUN_API_KEY` to return to wallet billing. New wallet users default
+Unset `BLOCKRUN_API_KEY` and restart Franklin to return to wallet billing. New wallet users default
 to Solana; existing chain choices and Base-only wallets are preserved.
 
 ## Quick start
+
+> **Release status:** As of September 4, 2026, npm `@blockrun/franklin@3.43.1` does not include this account API integration. The API instructions in this README apply to this source checkout; the global npm installation needs a release containing these changes.
 
 > **Requires Node.js 20.19+ (Node 22 LTS recommended).** Check with `node -v`. Older Node crashes at startup with `ERR_REQUIRE_ESM`.
 
@@ -94,11 +107,11 @@ npm install -g @blockrun/franklin
 franklin
 
 # 3. (optional) Fund a wallet to unlock Sonnet, Opus, GPT, Gemini, Grok, + paid APIs
-franklin setup base        # or: franklin setup solana
+franklin setup solana      # preferred for new wallets; or: franklin setup base
 franklin balance           # show address + USDC balance
 ```
 
-That's it. Zero signup, zero credit card, zero phone verification. Send **$5 of USDC** to the wallet and you've unlocked every frontier model and every paid tool in the BlockRun gateway.
+For wallet mode, no BlockRun signup is required: fund the wallet with USDC to use paid models and tools. For account mode, register at [user.blockrun.ai](https://user.blockrun.ai), add credits, and launch Franklin with `BLOCKRUN_API_KEY`. Prices and availability depend on the service.
 
 **No global install? Just run it directly** — no permissions, no `-g`:
 
@@ -130,7 +143,7 @@ npm install -g @blockrun/franklin
 
 [![Franklin for VS Code — Beta is here](assets/franklin-vscode-banner.png)](https://marketplace.visualstudio.com/items?itemName=blockrun.franklin-vscode)
 
-The same agent ships as a [VS Code extension](https://marketplace.visualstudio.com/items?itemName=blockrun.franklin-vscode) — chat panel, model picker, wallet balance, image / video generation, inline diff cards — all driven by the wallet you already funded for the CLI.
+The same agent ships as a [VS Code extension](https://marketplace.visualstudio.com/items?itemName=blockrun.franklin-vscode) — chat panel, model picker, wallet balance, image / video generation, inline diff cards — using account API billing or the wallet configured for the CLI.
 
 ```
 VS Code → Extensions  (Cmd+Shift+X / Ctrl+Shift+X)
@@ -138,7 +151,7 @@ VS Code → Extensions  (Cmd+Shift+X / Ctrl+Shift+X)
         → click the Franklin icon in the Activity Bar
 ```
 
-Free models work immediately. Paid models, image gen, and video gen activate the moment your wallet has USDC. The CLI and the extension share the same `~/.blockrun/` config and session history, so jumping between terminal and VS Code is seamless.
+Free models work immediately. Paid models and media require account credits or a funded wallet, plus availability of the requested service. The CLI and the extension share the same `~/.blockrun/` config and session history, so jumping between terminal and VS Code is seamless.
 
 ### Franklin Desktop (Beta)
 
@@ -178,13 +191,13 @@ packaging instructions.
 | ----------------------- | -------------------------------------------- | ------------------------------------ |
 | AI subscription       | Access. Paid whether you use it or not. | $20–200/month, rate-limited.         |
 | Pay-per-call (OpenAI API, etc.) | Every attempt — even failed ones.    | Hidden cost from retries, dead ends. |
-| **Franklin Agent (YOPO)**     | **The outcome.** Each signed micropayment.  | **Provider cost + 5%. No more.**     |
+| **Franklin Agent (YOPO)** | Model and tool usage, charged to account credits or an x402 wallet. | Service-specific pricing and account settings. |
 
 Three consequences fall out of this:
 
 1. **No subscriptions.** Use Franklin for $0.50 one week and $50 the next — you pay for compute actually consumed, nothing more.
-2. **No rate limits.** Subscriptions throttle you when you need AI most. YOPO has no artificial caps — if you have USDC, you have access.
-3. **No overdraft.** The wallet balance IS the hard limit. When it's empty, Franklin stops. No surprise bills, no 3 a.m. rate-limit walls.
+2. **Pay as you go.** Account and provider rate limits still apply. On HTTP 429, respect `Retry-After` and reduce concurrency.
+3. **Separate balances.** API calls use prepaid account credits; x402 calls use the selected wallet. An exhausted account returns a credit error and does not fall back to charging your wallet.
 
 Concretely — $1 in USDC gets you roughly:
 - ~400K GPT-4o input tokens
@@ -271,7 +284,7 @@ Every trade journals itself: thesis on open, P&L on close, written to a **wallet
   Saved: generated-logo-1713052800.png (1024x1024)
 ```
 
-Generates images via DALL-E / GPT Image directly from the CLI. Paid from your wallet — no OpenAI API key needed.
+Generates images via DALL-E / GPT Image directly from the CLI, billed to account credits or your wallet. No separate OpenAI API key is needed.
 
 ### 📱 Remote control via Telegram
 
@@ -306,7 +319,7 @@ Run `franklin telegram` on an always-on machine (set `TELEGRAM_BOT_TOKEN` + `TEL
 
 Code is still first-class. It is just **one workload**, not the category.
 
-Every tool call is itemized. Every token is priced. When the wallet hits zero, Franklin stops. No overdraft, no surprise bill, no rate-limit wall at 3 a.m. — this is YOPO in practice.
+Local cost views help track a session. In account mode, check Activity for authoritative charges; local estimates may differ, especially for media and service calls. Wallet and account balances remain separate.
 
 ---
 
@@ -343,7 +356,7 @@ Every response shows which model was chosen, why, and how much you saved vs. alw
 | `premium` | Highest quality regardless of cost | Mission-critical |
 | `free` | Free NVIDIA models only | Zero wallet balance |
 
-**Per-session breakdown** — run `/cost` to see exactly where your USDC went:
+**Per-session breakdown** — run `/cost` for local usage estimates; use account Activity for billed API usage:
 
 ```text
 Session Cost: $0.0847 (23 requests)
@@ -364,7 +377,7 @@ The router also learns from **your** usage. If you keep retrying a model for cod
 
 ### 💳 &nbsp;AI is utility, not SaaS
 
-You don't subscribe to electricity, you pay for what you use. Franklin brings the same model to AI. YOPO settlement means Franklin never bills you for access, only for outcomes. No monthly fees, no rate limits, no overdraft.
+Franklin charges for model and tool usage through account credits or x402 payments. Account and provider limits apply. Check the service price and your account settings before a large run.
 
 </td>
 <td width="33%" valign="top">
@@ -391,14 +404,14 @@ Choose an account API key, or wallet authentication on Solana or Base. Register 
 |                                        | Coding agents    | Editor IDEs      | Chatbots         | **Franklin**                    |
 | -------------------------------------- | ---------------- | ---------------- | ---------------- | ------------------------------- |
 | Writes code                            | ✅               | ✅               | ⚠️                | ✅                              |
-| **Spends money for you**               | ❌               | ❌               | ❌               | ✅ **USDC wallet, x402**        |
-| **Buys data + APIs + images + search** | ❌               | ❌               | ❌               | ✅ **55+ APIs, one wallet**     |
+| **Spends money for you**               | ❌               | ❌               | ❌               | ✅ **Account credits or USDC wallet**        |
+| **Buys data + APIs + images + search** | ❌               | ❌               | ❌               | ✅ **Paid APIs through one interface**     |
 | Picks best model per task              | ❌ single-vendor | ❌ plan-tied    | ❌               | ✅ **Smart Router, <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models** |
-| Pricing model                          | Subscription     | Subscription     | Subscription     | **YOPO** — per outcome, USDC    |
+| Pricing model                          | Subscription     | Subscription     | Subscription     | Usage-based account credits or x402 USDC    |
 | Monthly fee                            | $20–$200         | $20–$40          | $20+             | **$0**                          |
-| Rate-limited                           | Yes              | Yes              | Yes              | No — limited only by wallet     |
+| Rate-limited                           | Yes              | Yes              | Yes              | Account and provider limits apply     |
 | Works when provider goes down          | ❌               | ❌               | ❌               | ✅ **routes to another**        |
-| Identity                               | Vendor account   | Vendor account   | Account / email  | ✅ **wallet, no signup**        |
+| Identity                               | Vendor account   | Vendor account   | Account / email  | ✅ **Account login or wallet**        |
 | Start free, no KYC                     | ❌               | ❌               | ❌               | ✅                              |
 | Source                                 | Closed           | Closed           | Closed           | **Apache 2.0, local-first**     |
 
@@ -419,13 +432,13 @@ Franklin can decide what is worth paying for, route the call, sign the micropaym
 Ask "what's BTC looking like?" — Franklin fetches live price data, computes RSI/MACD/Bollinger/volatility, and synthesizes a signal.
 
 **🎨 AI image generation**
-Ask "generate a logo" — Franklin calls DALL-E / GPT Image, saves the result locally, paid from your wallet.
+Ask "generate a logo" — Franklin calls DALL-E / GPT Image, saves the result locally, billed to account credits or your wallet.
 
-**🧠 <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models via one wallet**
-Anthropic, OpenAI, Google, xAI, DeepSeek, GLM, Kimi, Minimax, NVIDIA free tier. One wallet, one interface, automatic fallback.
+**🧠 <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models via one account key or wallet**
+Anthropic, OpenAI, Google, xAI, DeepSeek, GLM, Kimi, Minimax, NVIDIA free tier. One account key or wallet, one interface, automatic model fallback.
 
 **💳 x402 micropayments (YOPO)**
-HTTP 402 native. Every paid action is a signed USDC micropayment via EIP-712 — non-custodial, your keys never leave your machine. YOPO: you pay only for outcomes.
+Account mode sends a Bearer API key to the account gateway and charges credits. Wallet mode signs x402 USDC payments locally on Solana or Base; private keys remain local. Model fallback keeps the selected billing mode.
 
 **🧠 Learned model router**
 Trained on 2M+ real requests. Classifies your task and picks the best model from <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> LLMs. Four profiles (auto/eco/premium/free). Adapts to your usage over time.
@@ -492,21 +505,21 @@ Core is workflow-agnostic. Add new verticals without touching the loop. Discover
 │  BlockRun Gateway                                            │
 │  <!-- br:models.chatVisible@live -->76<!-- /br:models.chatVisible@live --> LLMs · CoinGecko · Search · Image APIs · paid services  │
 ├──────────────────────────────────────────────────────────────┤
-│  x402 Micropayment Protocol                                  │
-│  HTTP 402 · USDC on Solana & Base · signed payment payloads  │
+│  Account API credits or x402 wallet payments                 │
+│  Bearer API key · or signed USDC on Solana & Base             │
 └──────────────────────────────────────────────────────────────┘
                             │
                             ▼
                      ┌─────────────┐
-                     │ Your wallet │
-                     │  (you own)  │
+                     │  Credits or │
+                     │ your wallet │
                      └─────────────┘
 ```
 
 The loop is simple:
 1. You state an outcome.
 2. Franklin chooses what to read, call, and pay for.
-3. The payment settles against your wallet.
+3. The call is billed to account credits or the selected x402 wallet.
 4. Franklin reports the result and the spend.
 
 That economic loop is the product.
@@ -550,7 +563,7 @@ Start with **zero dollars**. Franklin defaults to free NVIDIA models that need n
 franklin --model free
 ```
 
-When you fund the wallet, Franklin gets more purchasing power: Sonnet, Opus, GPT, Gemini, Grok, and paid tools like Exa, DALL-E, and CoinGecko Pro.
+With account credits or a funded wallet, Franklin can access paid services: Sonnet, Opus, GPT, Gemini, Grok, and paid tools like Exa, DALL-E, and CoinGecko Pro.
 
 ---
 
@@ -653,11 +666,23 @@ Apache-2.0. See [LICENSE](LICENSE).
 
 <div align="center">
 
-**The AI agent with a wallet.**<br>
-<sub>YOPO — You Only Pay Outcome. Your wallet. Your budget. Your results.</sub>
+**The AI agent with a budget.**<br>
+<sub>Account credits or your wallet. Your budget. Your results.</sub>
 
 <br>
 
 <sub>From the team at <a href="https://blockrun.ai">BlockRun</a>.</sub>
 
 </div>
+
+
+## Account setup, billing, and switching back to wallets
+
+1. [Sign in to BlockRun](https://user.blockrun.ai), open [Billing](https://user.blockrun.ai/dashboard/credits), and add prepaid account credits. The checkout shows both the credit amount and the total card charge, including any processing fee; these amounts can differ.
+2. Create a key on [API Keys](https://user.blockrun.ai/dashboard/keys). Keep it in your server or local process environment as `BLOCKRUN_API_KEY`; never put it in browser code, logs, or a repository. Follow this README's client configuration example.
+3. Check [Activity](https://user.blockrun.ai/dashboard/activity) after a call. Chat uses reported token usage; media and data services can use per-image, duration, or per-request prices. Account credits and an on-chain USDC wallet are separate balances. Local wallet spend counters are not account receipts.
+4. A 401 means check the API key, 402 means check account credits or account status, and 429 means respect `Retry-After`. Poll an accepted media job using the complete returned `poll_url`, including its query parameters, with the same account key. Do not reconstruct the URL from the job ID. If polling times out, check that job and Activity before submitting another paid job.
+
+Accepted account jobs recover from temporary gateway polling errors by querying the same job within the original deadline. They do not resubmit the paid creation request. Authentication, credit, and rate-limit errors remain visible to the caller.
+
+To return to wallet billing, unset `BLOCKRUN_API_KEY` in the environment that launches Franklin, then restart it. The existing wallet and saved chain selection remain in place. Changing the wallet chain while an API key is configured does not switch the billing source.

--- a/apps/desktop/src/components/WalletPanel.tsx
+++ b/apps/desktop/src/components/WalletPanel.tsx
@@ -31,6 +31,18 @@ function shortModel(id: string): string {
 // comes from the CLI wallet (useUsdcBalance → useWallet), and receipts come
 // from the CLI's authoritative settlement ledger through useSpend.
 export function WalletPanel({ usage }: { usage: Usage }) {
+  const { wallet } = useWallet();
+  if (wallet?.authMode === "api-key") return <div className="try-wallet-panel"><div className="try-wallet-inner">
+    <h2 className="try-tools-h">BlockRun account</h2>
+    <p>Models, media, search and data use your API key. Local cost totals are estimates.</p>
+    <a href="https://user.blockrun.ai/dashboard/credits" target="_blank" rel="noopener noreferrer">Manage credits and account usage</a>
+    <p>On-chain transactions require a separate transaction wallet.</p>
+  </div></div>;
+  if (!wallet) return <p>Loading account status…</p>;
+  return <WalletTransactionPanel usage={usage} />;
+}
+
+function WalletTransactionPanel({ usage }: { usage: Usage }) {
   const { t, lang } = useTryLang();
   const { balance } = useUsdcBalance();
   const { wallet, switchingChain, switchChain, error: walletError } = useWallet();
@@ -47,7 +59,7 @@ export function WalletPanel({ usage }: { usage: Usage }) {
         <section className="try-wallet-network-card">
           <div><strong>Payment network</strong><small>Franklin keeps a separate local wallet for each network. Switching restarts the local agent, never exports a key.</small></div>
           <div className="try-wallet-network-options" role="group" aria-label="Payment network">
-            {(["base", "solana"] as const).map((chain) => <button key={chain} className={wallet?.chain === chain ? "is-active" : ""} disabled={!!switchingChain || !wallet} onClick={() => void switchChain(chain)}>{switchingChain === chain ? <RefreshCw className="spin" /> : wallet?.chain === chain ? <Check /> : null}{chain === "base" ? "Base" : "Solana"}</button>)}
+            {(["solana", "base"] as const).map((chain) => <button key={chain} className={wallet?.chain === chain ? "is-active" : ""} disabled={!!switchingChain || !wallet} onClick={() => void switchChain(chain)}>{switchingChain === chain ? <RefreshCw className="spin" /> : wallet?.chain === chain ? <Check /> : null}{chain === "base" ? "Base" : "Solana"}</button>)}
           </div>
         </section>
         {walletError && <div className="cloud-error">{walletError}</div>}

--- a/apps/desktop/src/components/WalletPill.tsx
+++ b/apps/desktop/src/components/WalletPill.tsx
@@ -48,6 +48,13 @@ export function WalletPill({ wallet, connectionState, isLoading, error, switchin
     );
   }
 
+  if (wallet.authMode === "api-key") return (
+    <div className="try-wallet"><div className="try-wallet-info">
+      <span className="try-wallet-net">Account API key</span>
+      <a className="try-wallet-addr" href="https://user.blockrun.ai/dashboard/credits" target="_blank" rel="noopener noreferrer">Manage credits and usage</a>
+    </div></div>
+  );
+
   const net = wallet.chain === "base" ? "Base" : "Solana";
   // RPC values are runtime data, even when the TypeScript contract says
   // `string`. Keep a malformed wallet response from taking down the whole UI.

--- a/apps/desktop/src/lib/wire.ts
+++ b/apps/desktop/src/lib/wire.ts
@@ -184,8 +184,10 @@ export interface SessionSummary {
 
 export interface WalletInfo {
   address: string;
-  chain: "base" | "solana";
+  chain: "base" | "solana" | "account";
   balanceUsd?: number;
+  authMode?: "wallet" | "api-key";
+  portalUrl?: string;
 }
 
 export interface ModelInfo {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@blockrun/franklin",
   "version": "3.43.1",
-  "description": "Franklin Agent \u2014 The AI agent with a wallet. Spends USDC autonomously to get real work done. Pay per action, no subscriptions.",
+  "description": "Franklin Agent \u2014 AI agent with account API keys or USDC wallets on Solana and Base. Pay per action, no subscriptions.",
   "type": "module",
   "exports": {
     ".": {
@@ -38,7 +38,7 @@
     "desktop:package:win": "npm run dist:win --workspace @blockrun/franklin-desktop",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
-    "test": "npm run build && node --test --test-concurrency=4 --test-reporter=spec test/local.mjs test/serve-security.local.mjs test/skills.local.mjs test/repair.mjs test/model-resolver.mjs test/exa.local.mjs test/audit-batch.local.mjs test/polymarket.local.mjs test/market.local.mjs test/hooks.local.mjs test/scheduler.local.mjs test/trade-plan.local.mjs test/goal.local.mjs test/memory.local.mjs test/agent-host.local.mjs test/reservation.local.mjs",
+    "test": "npm run build && node --test --test-concurrency=4 --test-reporter=spec test/api-key.local.mjs test/local.mjs test/serve-security.local.mjs test/skills.local.mjs test/repair.mjs test/model-resolver.mjs test/exa.local.mjs test/audit-batch.local.mjs test/polymarket.local.mjs test/market.local.mjs test/hooks.local.mjs test/scheduler.local.mjs test/trade-plan.local.mjs test/goal.local.mjs test/memory.local.mjs test/agent-host.local.mjs test/reservation.local.mjs",
     "test:e2e": "npm run build && node --test --test-reporter=spec test/e2e.mjs",
     "e2e:polymarket:readonly": "npm run build && node scripts/polymarket-e2e-readonly.mjs",
     "test:free-models": "npm run build && node --test --test-reporter=spec test/free-model-matrix.mjs",

--- a/src/agent/commands.ts
+++ b/src/agent/commands.ts
@@ -1,3 +1,4 @@
+import { accountMode, ACCOUNT_PORTAL } from '../payments/account.js';
 /**
  * Slash command registry for Franklin.
  * Extracted from loop.ts for maintainability.
@@ -1227,6 +1228,12 @@ export async function handleSlashCommand(
       } catch (err) {
         ctx.onEvent({ kind: 'text_delta', text: `Import error: ${(err as Error).message}\n` });
       }
+      emitDone(ctx);
+      return { handled: true };
+    }
+
+    if (accountMode()) {
+      ctx.onEvent({ kind: "text_delta", text: `Account API mode. Balance and usage: ${ACCOUNT_PORTAL}/dashboard\n` });
       emitDone(ctx);
       return { handled: true };
     }

--- a/src/agent/context.ts
+++ b/src/agent/context.ts
@@ -248,18 +248,20 @@ function getBlockRunApiSection(): string {
 You run on the BlockRun AI Gateway. When the user asks you to "test the BlockRun API", "check all endpoints", or call the gateway directly, use ONLY the paths below. **Never invent, pluralize, or singularize an endpoint** — \`/v1/image/generate\` (singular) is wrong, \`/v1/images/generations\` (plural) is correct. If a path you have in mind isn't in this list, fetch the canonical discovery endpoints before calling it.
 
 **Base URLs**
-- Base chain: \`https://blockrun.ai/api\` (alias: \`https://api.blockrun.ai\`)
-- Solana chain: \`https://sol.blockrun.ai/api\`
+- Account API: \`https://api.blockrun.ai\` with the configured BlockRun bearer key; no payment chain. This is a separate account service, not an alias of the Base wallet gateway.
+- Solana x402 wallet: \`https://sol.blockrun.ai/api\`
+- Base x402 wallet: \`https://blockrun.ai/api\`
+Use the built-in tools so they apply the active authentication. Never print credentials, switch billing modes to recover from an API error, or attach wallet payment proofs to account requests.
 
 **Discovery (always free, GET) — fetch these BEFORE guessing a path**
 - \`GET /openapi.json\` (or \`/.well-known/openapi.json\`) — full OpenAPI 3.1 contract, every route + request schema
 - \`GET /.well-known/x402\` — x402 resource list with prices
 
-**LLM (POST, x402-paid)**
+**LLM (POST, billed to account credits or x402 wallet)**
 - \`POST /v1/chat/completions\` — OpenAI-compatible. Body: \`{ model, messages, stream?, tools?, max_tokens?, temperature? }\`. \`model\` MUST come from \`GET /v1/models\` (real frontier examples on the gateway, verified live 2026-08-30: \`anthropic/claude-sonnet-5\`, \`anthropic/claude-opus-5\`, \`openai/gpt-5.6-sol\`, \`deepseek/deepseek-v4-pro\`, \`zai/glm-5.3\`, \`zai/glm-5.3-flash\`, \`xai/grok-4.5\`, \`qwen/qwen3.7-flash\`, \`nvidia/nemotron-3-nano-omni-30b-a3b-reasoning\` (free, the only free id on BOTH the Base and Solana gateways — the other free models are Base-only)). Do NOT invent versions like \`openai/gpt-5.1\` or \`xai/grok-5\` — those don't exist; the gateway 400s with the valid list in the error body, so when in doubt fetch \`GET /v1/models\` first.
 - \`POST /v1/messages\` — Anthropic-compatible. Body: \`{ model, messages, max_tokens, system?, tools? }\`.
 
-**Media (POST, x402-paid; GET to poll async jobs)**
+**Media (POST, billed to account credits or x402 wallet; GET to poll async jobs)**
 - \`POST /v1/images/generations\` — text-to-image. Body: \`{ model, prompt, size?, n?, response_format? }\`.
 - \`POST /v1/images/image2image\` — image-to-image. Body: \`{ model, prompt, image, ... }\`.
 - \`GET  /v1/images/generations/{id}\` — fetch a generated image by id.
@@ -267,7 +269,7 @@ You run on the BlockRun AI Gateway. When the user asks you to "test the BlockRun
 - \`GET  /v1/videos/generations/{id}\` — poll video job (settles payment when complete).
 - \`POST /v1/audio/generations\` — music/audio. Body: \`{ model, prompt, ... }\`. Default \`model\`: \`minimax/music-2.5+\`.
 
-**Search (POST, x402-paid)**
+**Search (POST, billed to account credits or x402 wallet)**
 - \`POST /v1/search\` — Exa-backed web search. Body: \`{ query }\` (1–1000 chars).
 - \`/v1/exa/{...path}\` — Exa passthrough (answer / search / contents).
 

--- a/src/agent/context.ts
+++ b/src/agent/context.ts
@@ -1,3 +1,4 @@
+import { accountMode, ACCOUNT_PORTAL } from '../payments/account.js';
 /**
  * Context Manager for Franklin
  * Assembles system instructions, reads project config, injects environment info.
@@ -181,6 +182,7 @@ Do NOT check access before acting. Do NOT explain what you tried. Just deliver, 
 }
 
 function getWalletKnowledgeSection(): string {
+  if (accountMode()) return `# BlockRun account billing\nModel, media, search and data requests use the configured API key. No wallet is needed. Account balance/usage: ${ACCOUNT_PORTAL}/dashboard; top up: ${ACCOUNT_PORTAL}/dashboard/credits. Never inspect or print BLOCKRUN_API_KEY. Actual on-chain transactions still require a separately configured transaction wallet. Local cost totals are estimates, not the account ledger.`;
   // Read the panel URL persisted by startPanelBackground (start.ts) so we
   // surface the actual bound port — the panel auto-increments past 3100
   // when the default is taken (e.g. a second franklin running). Falls back
@@ -213,7 +215,7 @@ Franklin stores wallet keys in ~/.blockrun/. When the user asks about wallet loc
   - Use \`franklin stats\` / \`franklin content list\` instead of parsing files when the user asks "how much did I spend".
 - Programmatic access: import { getWalletAddress, getOrCreateWallet, getOrCreateSolanaWallet } from '@blockrun/llm'
 
-When the user asks about "my wallet" without qualifier, default to Base (it's the primary chain shown at launch). Only mention Solana if the chain file says solana or the user explicitly asks.
+When the user asks about "my wallet", use the saved active chain. New users default to Solana; preserve existing Base selections.
 
 ## Funding the wallet ("how do I deposit / recharge / fund / top up", in any language)
 

--- a/src/agent/error-classifier.ts
+++ b/src/agent/error-classifier.ts
@@ -1,3 +1,4 @@
+import { ACCOUNT_PORTAL } from '../payments/account.js';
 /**
  * Classify model/runtime errors so recovery and UX can be more consistent.
  *
@@ -52,6 +53,7 @@ function includesAny(text: string, patterns: string[]): boolean {
 
 export function classifyAgentError(message: string): AgentErrorInfo {
   const err = message.toLowerCase();
+  if (err.includes("account credits exhausted")) return { category: "payment", label: "Payment", isTransient: false, maxRetries: 0, suggestion: `Top up at ${ACCOUNT_PORTAL}/dashboard/credits.` };
 
   // Extract Retry-After hint that streaming-client appended (see llm.ts
   // 429 path). Surfaces on the AgentErrorInfo so the loop can honor the

--- a/src/agent/intent-prefetch.ts
+++ b/src/agent/intent-prefetch.ts
@@ -1,3 +1,4 @@
+import { gatewayFetch as fetch, accountMode } from '../payments/account.js';
 /**
  * Proactive prefetch for live-world questions.
  *
@@ -222,7 +223,7 @@ async function exaAnswerTry(query: string, client: ModelClient): Promise<{ text:
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ query }),
     });
-    if (res.status === 402) {
+    if (res.status === 402 && !accountMode()) {
       const payHdr = await extractPaymentReq(res);
       if (!payHdr) return { text: null, costUsd: 0 };
       const { getOrCreateWallet, getOrCreateSolanaWallet, createPaymentPayload, createSolanaPaymentPayload,

--- a/src/agent/llm.ts
+++ b/src/agent/llm.ts
@@ -1,3 +1,4 @@
+import { gatewayFetch as fetch, accountMode } from '../payments/account.js';
 /**
  * LLM Client for Franklin
  * Calls BlockRun API directly with x402 payment handling and streaming.
@@ -806,7 +807,7 @@ export class ModelClient {
       );
 
       // Handle x402 payment
-      if (response.status === 402) {
+      if (response.status === 402 && !accountMode()) {
         if (this.debug) console.error('[franklin] Payment required — signing...');
         const signedPayment = await this.signPayment(response, request.model);
         if (!signedPayment) {
@@ -897,7 +898,7 @@ export class ModelClient {
             createModelTimeoutError('request', request.model, requestTimeoutMs),
             requestTimeoutMs,
           );
-          if (response.status === 402) {
+          if (response.status === 402 && !accountMode()) {
             const signedPayment = await this.signPayment(response, request.model);
             if (!signedPayment) {
               yield { kind: 'error', payload: { message: 'Payment signing failed' } };
@@ -1393,7 +1394,7 @@ export class ModelClient {
     // A post-signature 402 means the gateway rejected the payment rather than
     // settling it. Keep both the session cost and cost_log anchored to calls
     // the gateway accepted after the paid retry returned.
-    if (response.status === 402) return;
+    if (response.status === 402 && !accountMode()) return;
     this.lastPaidUsd += payment.amountUsd;
     appendSettlementRow(payment.endpoint, payment.amountUsd, payment.meta);
   }

--- a/src/commands/balance.ts
+++ b/src/commands/balance.ts
@@ -1,8 +1,10 @@
+import { accountMode, ACCOUNT_PORTAL, validateAccountConfig } from '../payments/account.js';
 import chalk from 'chalk';
 import { setupAgentWallet, setupAgentSolanaWallet } from '@blockrun/llm';
 import { loadChain } from '../config.js';
 
 export async function balanceCommand() {
+  if (accountMode()) { validateAccountConfig(); console.log(`Account API mode. Balance and credits: ${ACCOUNT_PORTAL}/dashboard/credits`); return; }
   const chain = loadChain();
 
   try {

--- a/src/commands/proxy.ts
+++ b/src/commands/proxy.ts
@@ -1,3 +1,4 @@
+import { accountMode, ACCOUNT_PORTAL, validateAccountConfig, accountBaseURL } from '../payments/account.js';
 /**
  * Proxy-only mode — runs the BlockRun payment proxy for Anthropic-compatible CLI agents.
  * The proxy translates requests and handles x402 payments so any compatible client can use any model.
@@ -32,6 +33,13 @@ export async function proxyCommand(options: ProxyOptions) {
   }
 
   const model = options.model || config['default-model'];
+
+  if (accountMode()) {
+    validateAccountConfig();
+    console.log(`Account API proxy: http://localhost:${port} — ${ACCOUNT_PORTAL}/dashboard`);
+    launchProxy(createProxy({ port, apiUrl: accountBaseURL(), chain, modelOverride: model, debug: options.debug, fallbackEnabled: false }), port, options.debug);
+    return;
+  }
 
   if (chain === 'solana') {
     const wallet = await getOrCreateSolanaWallet();

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -1,3 +1,4 @@
+import { accountMode, ACCOUNT_PORTAL, validateAccountConfig } from '../payments/account.js';
 import chalk from 'chalk';
 import {
   getOrCreateWallet,
@@ -8,6 +9,7 @@ import {
 import { type Chain, saveChain } from '../config.js';
 
 export async function setupCommand(chainArg?: string) {
+  if (accountMode()) { validateAccountConfig(); console.log(`API key configured. Account credits and usage: ${ACCOUNT_PORTAL}/dashboard`); return; }
   // Solana is the default chain; `franklin setup base` opts into Base.
   const chain: Chain =
     chainArg === 'base' ? 'base' : 'solana';

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -1,3 +1,4 @@
+import { accountMode, ACCOUNT_PORTAL, validateAccountConfig } from '../payments/account.js';
 import chalk from 'chalk';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -226,8 +227,11 @@ export async function startCommand(options: StartOptions) {
   console.log(chalk.dim(`  Model: ${model}\n`));
 
   // Auto-create wallet if needed (no interruption — free models work without funding)
+  validateAccountConfig();
   let walletAddress = '';
-  if (chain === 'solana') {
+  if (accountMode()) {
+    console.log(chalk.cyan(`  Account API key • ${ACCOUNT_PORTAL}/dashboard`));
+  } else if (chain === 'solana') {
     const wallet = await getOrCreateSolanaWallet();
     walletAddress = wallet.address;
     if (wallet.isNew) {
@@ -263,7 +267,7 @@ export async function startCommand(options: StartOptions) {
 
   // Session info — aligned, minimal. Model + balance live in the input bar below.
   // Full wallet address is shown so the user can copy-paste it to fund the wallet.
-  console.log(chalk.dim('  Wallet:    ') + (walletAddress || chalk.yellow('not set')));
+  console.log(chalk.dim(accountMode() ? '  Account:   ' : '  Wallet:    ') + (accountMode() ? ACCOUNT_PORTAL : walletAddress || chalk.yellow('not set')));
   console.log(chalk.dim('  Dir:       ') + workDir);
   console.log(chalk.dim('  Dashboard: ') + (panelUrl ? chalk.cyan(panelUrl) : chalk.cyan('franklin panel') + chalk.dim(' → http://localhost:3100')));
   console.log(chalk.dim('  Help:      ') + chalk.cyan('/help'));
@@ -277,6 +281,7 @@ export async function startCommand(options: StartOptions) {
   // is provably non-empty. retryFetchBalance does one extra round-trip on a
   // zero result; genuinely empty wallets still resolve to $0.00 quickly.
   const fetchBalance = async (): Promise<string> => {
+    if (accountMode()) return "Account credits · user.blockrun.ai";
     try {
       const bal = await retryFetchBalance(async () => {
         if (chain === 'solana') {
@@ -297,8 +302,8 @@ export async function startCommand(options: StartOptions) {
   // Fetch balance in background (don't block startup)
   const walletInfo: { address: string; balance: string; chain: string } = {
     address: walletAddress,
-    balance: 'checking...',
-    chain,
+    balance: accountMode() ? 'Account credits · user.blockrun.ai' : 'checking...',
+    chain: accountMode() ? 'account' : chain,
   };
   // Balance fetch callback — will update Ink UI once resolved
   let onBalanceFetched: ((bal: string) => void) | undefined;

--- a/src/gateway-models.ts
+++ b/src/gateway-models.ts
@@ -1,3 +1,4 @@
+import { gatewayFetch as fetch } from './payments/account.js';
 /**
  * Dynamic model catalog from BlockRun Gateway.
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,9 +41,9 @@ const program = new Command();
 program
   .name('franklin')
   .description(
-    'Franklin Agent — The AI agent with a wallet.\n\n' +
-      'While others chat, Franklin Agent spends — turning your USDC into real work.\n\n' +
-      'Pay per action in USDC on Base or Solana. No subscriptions. No accounts.'
+    'Franklin Agent — AI with account credits or a payment wallet.\n\n' +
+      'Use a BlockRun API key, or pay per action in USDC on Solana or Base.\n\n' +
+      'Register, create an API key, and add credits at https://user.blockrun.ai.'
   )
   .version(version);
 
@@ -158,7 +158,7 @@ program
 
 program
   .command('balance')
-  .description('Check wallet USDC balance')
+  .description('Show account billing information or wallet USDC balance')
   .action(balanceCommand);
 
 program

--- a/src/panel/html.ts
+++ b/src/panel/html.ts
@@ -1194,6 +1194,14 @@ async function loadLearnings() {
 async function loadWallet() {
   const w = await api('wallet');
   if (!w) return;
+  if (w.authMode === 'api-key') {
+    document.getElementById('wallet-address-full').textContent = 'Account API key';
+    document.getElementById('wallet-balance-big').textContent = 'Account credits';
+    document.getElementById('wallet-chain-pill').textContent = 'API';
+    document.getElementById('wallet-qr').innerHTML = '<a href="https://user.blockrun.ai/dashboard/credits" target="_blank" rel="noopener">Manage account credits and usage</a>';
+    document.getElementById('wallet-qr-hint').textContent = 'No wallet is required for API requests.';
+    return;
+  }
   const addr = w.address || '';
   document.getElementById('wallet-address-full').textContent = addr || 'not set';
   document.getElementById('wallet-balance-big').textContent = usdBig(w.balance) + ' USDC';

--- a/src/panel/server.ts
+++ b/src/panel/server.ts
@@ -1,3 +1,4 @@
+import { accountMode, accountStatus, ACCOUNT_PORTAL } from '../payments/account.js';
 /**
  * Franklin Panel — local HTTP server.
  * Serves the dashboard HTML + JSON API endpoints + SSE for real-time updates.
@@ -124,6 +125,7 @@ function broadcast(data: unknown): void {
  * empty state with a "Create wallet" CTA before any phone calls can be made.
  */
 async function currentWalletAddress(): Promise<string> {
+  if (accountMode()) throw new Error(`This action requires a transaction wallet; account billing is at ${ACCOUNT_PORTAL}/dashboard`);
   const chain = loadChain();
   if (chain === 'solana') {
     const { setupAgentSolanaWallet } = await import('@blockrun/llm');
@@ -298,6 +300,7 @@ export function createPanelServer(port: number): http.Server {
       }
 
       if (p === '/api/wallet') {
+        if (accountMode()) { json(res, accountStatus()); return; }
         try {
           const chain = loadChain();
           let address = '', balance = 0;
@@ -375,6 +378,7 @@ export function createPanelServer(port: number): http.Server {
       // Hardened: loopback-only (belt-and-suspenders on the 127.0.0.1 bind),
       // same-origin for browser requests, no-store cache header, JSON only.
       if (p === '/api/wallet/secret') {
+        if (accountMode()) { json(res, { error: 'Account keys are configured via BLOCKRUN_API_KEY and never exposed by the panel.' }, 409); return; }
         if (!isLocalPanelRequest(req)) {
           json(res, { error: 'forbidden' }, 403);
           return;

--- a/src/payments/account.ts
+++ b/src/payments/account.ts
@@ -1,0 +1,80 @@
+/** Shared account authentication for Franklin's direct gateway requests. */
+export const ACCOUNT_PORTAL = 'https://user.blockrun.ai';
+export function accountMode(): boolean { return process.env.BLOCKRUN_API_KEY !== undefined; }
+export function accountBaseURL(): string {
+  const raw = (process.env.BLOCKRUN_API_BASE_URL || 'https://api.blockrun.ai').replace(/\/+$/, '').replace(/\/v1$/, '');
+  const url = new URL(raw);
+  if (url.username || url.password || url.search || url.hash ||
+      (url.protocol !== 'https:' && !(url.protocol === 'http:' && ['localhost', '127.0.0.1', '[::1]'].includes(url.hostname)))) {
+    throw new Error('BLOCKRUN_API_BASE_URL requires HTTPS (except localhost) and no credentials, query or fragment.');
+  }
+  return raw;
+}
+export function accountStatus() {
+  return { authMode: 'api-key', address: '', chain: 'account', balance: null, balanceUsd: undefined, portalUrl: ACCOUNT_PORTAL, creditsUrl: `${ACCOUNT_PORTAL}/dashboard/credits` };
+}
+
+function key(): string {
+  const value = process.env.BLOCKRUN_API_KEY?.trim() || '';
+  if (!/^brk_[A-Za-z0-9_-]+$/.test(value)) throw new Error(`Invalid BLOCKRUN_API_KEY. Create a key at ${ACCOUNT_PORTAL}/dashboard/keys.`);
+  return value;
+}
+export function validateAccountConfig(): void { if (accountMode()) { key(); accountBaseURL(); } }
+
+function accountRequestURL(input: string | URL | Request): URL {
+  const base = new URL(accountBaseURL());
+  const source = new URL(input instanceof Request ? input.url : String(input), `${base}/`);
+  const gateways = new Set(['https://blockrun.ai', 'https://sol.blockrun.ai', 'https://api.blockrun.ai', base.origin]);
+  if (!gateways.has(source.origin) || source.username || source.password) throw new Error('Refusing to forward an account key to an unknown gateway or polling origin.');
+  source.protocol = base.protocol; source.host = base.host;
+  source.pathname = source.pathname.replace(/^\/api\/v1\//, '/v1/');
+  return source;
+}
+
+// Caller receives the actual HTTP status, so existing stream parsers and proxy
+// clients keep their error semantics. No x402 branch may run in account mode.
+export async function gatewayFetch(input: string | URL | Request, init?: RequestInit): Promise<Response> {
+  if (!accountMode()) return globalThis.fetch(input, init);
+  const credential = key();
+  const url = accountRequestURL(input);
+  const request = input instanceof Request ? input : undefined;
+  const headers = new Headers(init?.headers ?? request?.headers);
+  for (const name of [...headers.keys()]) if (/payment/i.test(name) || /^(x-api-key|authorization)$/i.test(name)) headers.delete(name);
+  headers.set('authorization', `Bearer ${credential}`);
+  const response = await globalThis.fetch(request ? new Request(url, request) : url, { ...init, headers, redirect: 'error' });
+  if (response.ok) return response;
+  let body: unknown;
+  try { body = await response.json(); } catch { body = {}; }
+  const outer = body && typeof body === 'object' ? body as Record<string, unknown> : {};
+  const detail = outer.error && typeof outer.error === 'object' ? outer.error as Record<string, unknown> : outer;
+  const safe = Object.fromEntries(['message', 'code', 'type', 'param'].flatMap(name => typeof detail[name] === 'string' ? [[name, (detail[name] as string).split(credential).join('[REDACTED]')]] : []));
+  if (response.status === 402) safe.message = `BlockRun account credits exhausted (402). Top up at ${ACCOUNT_PORTAL}/dashboard/credits.`;
+  if (response.status === 401) safe.message = `BlockRun account authentication failed (401). Check your key at ${ACCOUNT_PORTAL}/dashboard/keys.`;
+  const safeHeaders = new Headers({ 'content-type': 'application/json' });
+  const retryAfter = response.headers.get('retry-after'); if (retryAfter) safeHeaders.set('retry-after', retryAfter);
+  return new Response(JSON.stringify({ error: safe }), { status: response.status, headers: safeHeaders });
+}
+
+/** Poll direct API jobs with an abortable deadline; never resubmit a job. */
+export async function pollAccountJob(response: Response, signal?: AbortSignal, intervalMs = 2000): Promise<Response> {
+  if (!accountMode() || response.status !== 202) return response;
+  const initial = await response.clone().json() as { poll_url?: string };
+  if (!initial.poll_url) throw new Error('Account async response missing poll_url');
+  const endpoint = accountRequestURL(initial.poll_url);
+  const deadline = AbortSignal.timeout(15 * 60_000);
+  const abort = signal ? AbortSignal.any([signal, deadline]) : deadline;
+  while (!abort.aborted) {
+    await new Promise<void>((resolve, reject) => {
+      const onAbort = () => { clearTimeout(timer); reject(abort.reason); };
+      const timer = setTimeout(() => { abort.removeEventListener('abort', onAbort); resolve(); }, intervalMs);
+      abort.addEventListener('abort', onAbort, { once: true });
+      if (abort.aborted) onAbort();
+    });
+    const polled = await gatewayFetch(endpoint, { signal: abort });
+    if (!polled.ok) return polled;
+    const data = await polled.clone().json() as { status?: string };
+    if (data.status === 'completed') return polled;
+    if (['failed', 'cancelled', 'canceled'].includes(data.status || '')) throw new Error('Account job failed or was cancelled');
+  }
+  throw new Error('Account job polling stopped; check job before resubmitting');
+}

--- a/src/payments/account.ts
+++ b/src/payments/account.ts
@@ -71,6 +71,10 @@ export async function pollAccountJob(response: Response, signal?: AbortSignal, i
       if (abort.aborted) onAbort();
     });
     const polled = await gatewayFetch(endpoint, { signal: abort });
+    if ([502, 503, 504, 522, 524].includes(polled.status)) {
+      await polled.body?.cancel();
+      continue;
+    }
     if (!polled.ok) return polled;
     const data = await polled.clone().json() as { status?: string };
     if (data.status === 'completed') return polled;

--- a/src/payments/post-with-payment.ts
+++ b/src/payments/post-with-payment.ts
@@ -1,3 +1,4 @@
+import { gatewayFetch as fetch, accountMode, pollAccountJob } from './account.js';
 /**
  * Shared x402 POST helper.
  *
@@ -120,7 +121,7 @@ export async function postWithPayment(
       body: payload,
     });
 
-    if (response.status === 402) {
+    if (response.status === 402 && !accountMode()) {
       const paymentHeaders = await signPayment(response, chain, endpoint, resourceDescription);
       if (!paymentHeaders) {
         return { ok: false, status: 402, body: { error: 'payment signing failed' }, raw: '' };
@@ -133,6 +134,7 @@ export async function postWithPayment(
       });
     }
 
+    response = await pollAccountJob(response, ctrl.signal);
     const raw = await response.text().catch(() => '');
     let parsed: Record<string, unknown> = {};
     try { parsed = raw ? JSON.parse(raw) : {}; } catch { /* leave as {} */ }

--- a/src/proxy/fallback.ts
+++ b/src/proxy/fallback.ts
@@ -1,3 +1,4 @@
+import { gatewayFetch as fetch } from '../payments/account.js';
 /**
  * Fallback chain for Franklin
  * Automatically switches to backup models when primary fails (429, 5xx, etc.)

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1,3 +1,4 @@
+import { gatewayFetch as fetch, accountMode } from '../payments/account.js';
 import http from 'node:http';
 import {
   getOrCreateWallet,
@@ -264,9 +265,9 @@ export function createProxy(options: ProxyOptions): http.Server {
   // happen regardless; only the live stderr mirror is gated.
   setDebugMode(!!options.debug);
 
-  const chain = options.chain || 'base';
+  const chain = options.chain || 'solana';
   let currentModel: string | null = options.modelOverride || DEFAULT_MODEL;
-  const fallbackEnabled = options.fallbackEnabled !== false; // Default true
+  const fallbackEnabled = !accountMode() && options.fallbackEnabled !== false; // Default true
   // Resolve timeouts once at construction. The option wins over the env var
   // so callers (esp. tests) can configure a single proxy without polluting
   // process.env for the rest of the process — and for any sibling proxy.
@@ -276,14 +277,14 @@ export function createProxy(options: ProxyOptions): http.Server {
   let baseWallet: { privateKey: string; address: string } | null = null;
   let solanaWallet: { privateKey: string; address: string } | null = null;
 
-  if (chain === 'base') {
+  if (!accountMode() && chain === 'base') {
     const w = getOrCreateWallet();
     baseWallet = { privateKey: w.privateKey, address: w.address };
   }
 
   let solanaInitPromise: Promise<void> | null = null;
   const initSolana = () => {
-    if (chain !== 'solana' || solanaWallet) return Promise.resolve();
+    if (accountMode() || chain !== 'solana' || solanaWallet) return Promise.resolve();
     if (!solanaInitPromise) {
       solanaInitPromise = getOrCreateSolanaWallet().then((w) => {
         solanaWallet = { privateKey: w.privateKey, address: w.address };
@@ -877,7 +878,7 @@ async function fetchModelAttempt(
   );
 
   // Non-402 path: free model or cached response — no payment, paidUsd = 0.
-  if (response.status !== 402) return { response, paidUsd: 0 };
+  if (accountMode() || response.status !== 402) return { response, paidUsd: 0 };
 
   if (payment.chain === 'solana' && payment.solanaWallet) {
     return handleSolanaPayment(
@@ -1043,7 +1044,7 @@ async function handleBasePayment(
     body: body || undefined,
   }, timeoutMs, `Paid proxy request for ${model}`);
 
-  if (paid.status === 402) return { response: paid, paidUsd: 0 };
+  if (paid.status === 402 && !accountMode()) return { response: paid, paidUsd: 0 };
   appendSettlementRow(endpoint, paidUsd, settlementMeta);
   return { response: paid, paidUsd };
 }
@@ -1107,7 +1108,7 @@ async function handleSolanaPayment(
     body: body || undefined,
   }, timeoutMs, `Paid proxy request for ${model}`);
 
-  if (paid.status === 402) return { response: paid, paidUsd: 0 };
+  if (paid.status === 402 && !accountMode()) return { response: paid, paidUsd: 0 };
   appendSettlementRow(endpoint, paidUsd, settlementMeta);
   return { response: paid, paidUsd };
 }

--- a/src/serve/cloud-sync.ts
+++ b/src/serve/cloud-sync.ts
@@ -1,3 +1,4 @@
+import { accountMode } from '../payments/account.js';
 /**
  * Cloud sync for desktop chat history — the local agent acts as the bridge.
  *
@@ -47,6 +48,7 @@ function getSetCookie(res: Response, name: string): string | null {
 }
 
 async function login(): Promise<void> {
+  if (accountMode()) throw new Error("Wallet-signed cloud sync is unavailable in account mode; local sessions remain available.");
   const nonceRes = await fetch(`${CLOUD_BASE}/api/try/auth/nonce`, { signal: AbortSignal.timeout(TIMEOUT) });
   if (!nonceRes.ok) throw new Error(`nonce ${nonceRes.status}`);
   const nonceCookie = getSetCookie(nonceRes, NONCE_COOKIE);

--- a/src/serve/server.ts
+++ b/src/serve/server.ts
@@ -1,3 +1,4 @@
+import { accountMode, accountStatus, ACCOUNT_PORTAL } from '../payments/account.js';
 /**
  * Franklin agent server (local WebSocket — drives the desktop app & browser UI).
  *
@@ -512,6 +513,7 @@ export async function startServer(opts: ServerOptions): Promise<void> {
   // ── Wallet balance (cached client) + post-turn broadcast ──
   let walletClient: Awaited<ReturnType<typeof setupAgentSolanaWallet>> | ReturnType<typeof setupAgentWallet> | null = null;
   async function getWallet() {
+    if (accountMode()) throw new Error(`This operation requires a transaction wallet; account billing is at ${ACCOUNT_PORTAL}/dashboard`);
     if (walletClient) return walletClient;
     const c = chain === 'solana'
       ? await setupAgentSolanaWallet({ silent: true })
@@ -520,6 +522,7 @@ export async function startServer(opts: ServerOptions): Promise<void> {
     return c;
   }
   async function fetchBalanceUsd(): Promise<number | undefined> {
+    if (accountMode()) return undefined;
     try {
       const client = await getWallet();
       return await retryFetchBalance(() => client.getBalance());
@@ -715,6 +718,7 @@ export async function startServer(opts: ServerOptions): Promise<void> {
         break;
       }
       case 'wallet.info': {
+        if (accountMode()) { send(ws, id, 'response', accountStatus()); break; }
         try {
           const client = await getWallet();
           // Solana resolves its public key asynchronously while Base returns it

--- a/src/skills-bundled/budget-grill/SKILL.md
+++ b/src/skills-bundled/budget-grill/SKILL.md
@@ -16,11 +16,14 @@ argument-hint: <plan or topic to grill on>
 cost-receipt: true
 ---
 
-You are running inside Franklin, an Economic Agent powered by an x402 USDC wallet on {{wallet_chain}}. The user funds the wallet directly; every paid call ($-priced tools, model API calls) draws against that balance, so wasteful spending shows up immediately on the receipt.
+**Active billing:** {{billing_context}}
+
+
+You are running inside Franklin, an Economic Agent using {{wallet_chain}}. Paid model and data calls draw from the active billing source described above. Use the account activity ledger for actual API charges; local receipts are estimates.
 
 Your job: interview the user relentlessly about the plan below, **one question at a time**, until you reach a shared understanding of every branch of the decision tree. For every question, also propose your recommended answer and the reasoning behind it.
 
-The thing that makes this skill different from a generic grilling session: **frame every option in cost terms**. For each branch, estimate the USDC spend per call/run/cycle, the model tier it would land on, and the worst-case wallet drain over the lifetime of the feature. If the option spends $0 because it's free-tier, say so explicitly. If it depends on a paid tool (`ExaSearch`, `ImageGen`, `VideoGen`, `MusicGen`, `TradingMarket` paid actions), name the tool and estimate the per-call cost.
+The thing that makes this skill different from a generic grilling session: **frame every option in cost terms**. For each branch, estimate the USD cost per call/run/cycle, the model tier it would land on, and the worst-case spend over the lifetime of the feature. If the option spends $0 because it's free-tier, say so explicitly. If it depends on a paid tool (`ExaSearch`, `ImageGen`, `VideoGen`, `MusicGen`, `TradingMarket` paid actions), name the tool and estimate the per-call cost.
 
 Rules of engagement:
 

--- a/src/skills-bundled/phone-call/SKILL.md
+++ b/src/skills-bundled/phone-call/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: phone-call
-description: Place an outbound AI-driven voice call (Bland.ai via BlockRun). Walks through intent capture, caller-ID selection, task scripting, and confirmation; fires VoiceCall, then auto-polls VoiceStatus until completion and surfaces the transcript. $0.54 per call, US/CA destinations only, charged from your wallet. Real-world action — use with prior consent.
+description: Place an outbound AI-driven voice call (Bland.ai via BlockRun). Walks through intent capture, caller-ID selection, task scripting, and confirmation; fires VoiceCall, then auto-polls VoiceStatus until completion and surfaces the transcript. $0.54 per call, US/CA destinations only, charged to the active billing source. Real-world action — use with prior consent.
 triggers:
   - "make a phone call"
   - "call this number"
@@ -13,7 +13,10 @@ argument-hint: <recipient + what to say>
 cost-receipt: true
 ---
 
-You are running inside Franklin on **{{wallet_chain}}**. This skill is Franklin's real-world action surface — it picks up a real phone, charges a real $0.54 from the user's wallet, and the recipient is a real human (or their voicemail). Be deliberate.
+**Active billing:** {{billing_context}}
+
+
+You are running inside Franklin on **{{wallet_chain}}**. This skill is Franklin's real-world action surface — it picks up a real phone, incurs a real charge through the active billing source, and the recipient is a real human (or their voicemail). Be deliberate.
 
 ## Workflow
 
@@ -53,7 +56,7 @@ Show the user, in plain text:
 
 - **To:** \`<recipient E.164>\`
 - **From:** \`<caller-ID E.164>\` (\<days-left\> days on lease)
-- **Cost:** $0.54 from wallet
+- **Cost:** use the current quote and state whether account credits or an x402 wallet will be charged
 - **Voice:** \`<preset>\` (default \`maya\`)
 - **Max duration:** \<N\> minutes (default 5)
 - **Task summary:** first 1–2 sentences

--- a/src/skills-bundled/surf-chain/SKILL.md
+++ b/src/skills-bundled/surf-chain/SKILL.md
@@ -19,10 +19,13 @@ argument-hint: <address, hash, or question>
 cost-receipt: true
 ---
 
+**Active billing:** {{billing_context}}
+
+
 You are running inside Franklin on **{{wallet_chain}}**. Use the `BlockRun` tool to call Surf's on-chain endpoints. The flagship capability here is **on-chain SQL** — write a query against 80+ indexed chain tables and get back a result set in sub-second.
 
 **Two different "chains" to keep straight:**
-1. **Payment chain** — where Franklin's wallet signs the x402 USDC payment. Currently `{{wallet_chain}}`. Surf only accepts settlement on **Base** (treasury `0x058a59…`). If the user is on Solana, ask them to `/chain base` before retrying.
+1. **Billing mode** — `{{wallet_chain}}`. In account API mode, use account credits and never suggest `/chain base` to fix authentication or credit errors. In wallet mode, the payment chain controls x402 settlement; if the gateway reports unsupported Solana settlement for Surf, explain the requirement before the user chooses Base.
 2. **Query chain** — the chain the data is *about*. Passed as a parameter to endpoints like `onchain/gas-price`, `onchain/tx`, `token/holders`, `token/transfers`. Valid values include `ethereum`, `base`, `arbitrum`, `polygon`, `optimism`, `bsc`. When the user doesn't specify and they're on `base`, default to `chain: "base"`. If they ask about Solana on-chain data, note that these EVM-shaped endpoints don't cover Solana — use a Solana-specific tool instead.
 
 ## How to use
@@ -31,7 +34,7 @@ You are running inside Franklin on **{{wallet_chain}}**. Use the `BlockRun` tool
 
 ## Endpoint catalog
 
-### Direct lookups (Tier 1, $0.001)
+### Direct lookups (Tier 1, $0.0075)
 | Path | Method | Required | What it returns |
 |---|---|---|---|
 | `/v1/surf/onchain/gas-price` | GET | `chain` | Current gas on the named chain |
@@ -39,20 +42,20 @@ You are running inside Franklin on **{{wallet_chain}}**. Use the `BlockRun` tool
 | `/v1/surf/onchain/bridge/ranking` | GET | — | Bridge protocols ranked by volume |
 | `/v1/surf/onchain/yield/ranking` | GET | — | Yield pools (lending, LP, staking) |
 
-### Raw + structured chain query (Tier 3, $0.02 — premium)
+### Raw + structured chain query (Tier 3, $0.0075)
 | Path | Method | Required | What it returns |
 |---|---|---|---|
 | `/v1/surf/onchain/schema` | GET | — | ClickHouse table schema introspection. **Always call this FIRST** before writing SQL so you know the tables, columns, and types. |
 | `/v1/surf/onchain/query` | POST | — (typed body) | Structured chain query with typed predicates. Safer than SQL when the question fits a fixed shape. |
 | `/v1/surf/onchain/sql` | POST | body: `{ query: string }` | Raw SQL against 80+ indexed tables. Sub-second. Use for novel questions that the typed query can't express. |
 
-### Token analytics (Tier 2, $0.005)
+### Token analytics (Tier 2, $0.0075)
 | Path | Method | Required | What it returns |
 |---|---|---|---|
 | `/v1/surf/token/holders` | GET | `address`, `chain` | Top token holders with balances |
 | `/v1/surf/token/transfers` | GET | `address`, `chain` | Token transfer history |
 
-### Wallet intelligence (Tier 2, $0.005)
+### Wallet intelligence (Tier 2, $0.0075)
 | Path | Method | Required | What it returns |
 |---|---|---|---|
 | `/v1/surf/wallet/detail` | GET | `address` | Aggregated wallet profile across chains |
@@ -64,29 +67,31 @@ You are running inside Franklin on **{{wallet_chain}}**. Use the `BlockRun` tool
 
 ## How to choose
 
-- **"What's gas on Base?"** → `onchain/gas-price` with `chain: "base"` ($0.001). One call, done.
+- **"What's gas on Base?"** → `onchain/gas-price` with `chain: "base"` ($0.0075). One call, done.
 - **"Look up this tx"** → `onchain/tx` with `hash` + `chain`.
-- **"Who owns this token?"** → `token/holders` ($0.005). Pair with `wallet/labels/batch` on the top 20 to see which holders are CEXes vs whales.
-- **"Profile this wallet"** → `wallet/detail` first ($0.005). If they want depth, follow up with `wallet/history`, `wallet/net-worth`, `wallet/protocols`.
+- **"Who owns this token?"** → `token/holders` ($0.0075). Pair with `wallet/labels/batch` on the top 20 to see which holders are CEXes vs whales.
+- **"Profile this wallet"** → `wallet/detail` first ($0.0075). If they want depth, follow up with `wallet/history`, `wallet/net-worth`, `wallet/protocols`.
 - **"Is this address a CEX / whale / MEV bot?"** → `wallet/labels/batch` — cheapest forensic call.
-- **"Bridge volume this week"** → `onchain/bridge/ranking` ($0.001).
-- **"Best yield on USDC right now"** → `onchain/yield/ranking` ($0.001), filter for USDC.
+- **"Bridge volume this week"** → `onchain/bridge/ranking` ($0.0075).
+- **"Best yield on USDC right now"** → `onchain/yield/ranking` ($0.0075), filter for USDC.
 
 ### On-chain SQL workflow
 
 For novel chain questions (e.g. "all addresses that received >100 ETH from Tornado in 2025"):
 
-1. **Schema first** — `BlockRun({ path: "/v1/surf/onchain/schema", method: "GET" })` ($0.02). Note the tables, columns, types.
-2. **Try structured query** — `BlockRun({ path: "/v1/surf/onchain/query", method: "POST", body: { /* typed predicates */ } })` ($0.02) when the shape fits.
-3. **Raw SQL fallback** — `BlockRun({ path: "/v1/surf/onchain/sql", method: "POST", body: { query: "SELECT …" } })` ($0.02) for anything else.
-4. **Validate** — if SQL fails parse or returns empty unexpectedly, fix the query and re-run. Each retry is $0.02 — be deliberate.
+1. **Schema first** — `BlockRun({ path: "/v1/surf/onchain/schema", method: "GET" })` ($0.0075). Note the tables, columns, types.
+2. **Try structured query** — `BlockRun({ path: "/v1/surf/onchain/query", method: "POST", body: { /* typed predicates */ } })` ($0.0075) when the shape fits.
+3. **Raw SQL fallback** — `BlockRun({ path: "/v1/surf/onchain/sql", method: "POST", body: { query: "SELECT …" } })` ($0.0075) for anything else.
+4. **Validate** — if SQL fails parse or returns empty unexpectedly, fix the query and re-run. Each retry is $0.0075 — be deliberate.
 
 ## Cost discipline
 
-- Wallet/token reads are $0.005 each. If you need 5 lookups, expect $0.025.
-- Tier-3 chain queries are $0.02/call. Plan the schema → query → result loop before firing; don't fire speculative SQL.
+- Wallet/token reads are $0.0075 each. If you need 5 lookups, expect $0.0375.
+- Tier-3 chain queries are $0.0075/call. Plan the schema → query → result loop before firing; don't fire speculative SQL.
 - Always include the cost in your summary back to the user.
 
 ## The user asked
 
 $ARGUMENTS
+
+Pricing reference: the account gateway currently lists Surf and Predexon service calls at $0.0075 per request. Confirm the current service quote before a batch; account Activity is the receipt, and wallet x402 quotes can also include payment-rail fees.

--- a/src/skills-bundled/surf-market/SKILL.md
+++ b/src/skills-bundled/surf-market/SKILL.md
@@ -17,9 +17,14 @@ argument-hint: <symbol or question>
 cost-receipt: true
 ---
 
-You are running inside Franklin on **{{wallet_chain}}**. Crypto market data lives behind the `BlockRun` tool, which signs USDC x402 payments from the user's wallet on every call. Pick the cheapest endpoint that answers the question.
+**Active billing:** {{billing_context}}
 
-**Chain note:** Surf currently settles x402 payments on **Base** only (treasury is `0x058a59…` on Base). If the user's active chain is `solana` and you hit a payment error, tell them to switch with `/chain base` before retrying — the request itself works, the wallet just needs to be on Base to sign the payment.
+
+You are running inside Franklin on **{{wallet_chain}}**. Crypto market data lives behind the `BlockRun` tool, which uses the configured account API key or x402 wallet for each call. Pick the cheapest endpoint that answers the question.
+
+**Account mode:** do not switch chains or fund a wallet for API errors. Check the key or account credits instead.
+
+**Chain note (wallet mode only):** Surf currently settles x402 payments on **Base** only (treasury is `0x058a59…` on Base). If the user's active chain is `solana` and you hit a payment error, tell them to switch with `/chain base` before retrying — the request itself works, the wallet just needs to be on Base to sign the payment.
 
 ## How to use
 
@@ -28,60 +33,60 @@ Call `BlockRun({ path: "/v1/surf/<endpoint>", method: "GET", params: { ... } })`
 ## Endpoint catalog
 
 ### Exchange (CEX intelligence)
-| Path | Tier | Required params | What it returns |
+| Path | Price/call | Required params | What it returns |
 |---|---|---|---|
-| `/v1/surf/exchange/markets` | $0.001 | — | Trading pairs catalog across major CEXes |
-| `/v1/surf/exchange/price` | $0.001 | `pair` | Ticker price for a pair |
-| `/v1/surf/exchange/perp` | $0.001 | `pair` | Perpetual contract snapshot |
-| `/v1/surf/exchange/depth` | $0.005 | `pair` | Order book depth |
-| `/v1/surf/exchange/klines` | $0.005 | `pair` | OHLCV candlesticks |
-| `/v1/surf/exchange/funding-history` | $0.005 | `pair` | Perp funding rate history |
-| `/v1/surf/exchange/long-short-ratio` | $0.005 | `pair` | Long/short positioning |
+| `/v1/surf/exchange/markets` | $0.0075 | — | Trading pairs catalog across major CEXes |
+| `/v1/surf/exchange/price` | $0.0075 | `pair` | Ticker price for a pair |
+| `/v1/surf/exchange/perp` | $0.0075 | `pair` | Perpetual contract snapshot |
+| `/v1/surf/exchange/depth` | $0.0075 | `pair` | Order book depth |
+| `/v1/surf/exchange/klines` | $0.0075 | `pair` | OHLCV candlesticks |
+| `/v1/surf/exchange/funding-history` | $0.0075 | `pair` | Perp funding rate history |
+| `/v1/surf/exchange/long-short-ratio` | $0.0075 | `pair` | Long/short positioning |
 
 ### Market (broad-market intelligence)
-| Path | Tier | Required params | What it returns |
+| Path | Price/call | Required params | What it returns |
 |---|---|---|---|
-| `/v1/surf/market/ranking` | $0.001 | — | Token ranking (market cap, volume, change) |
-| `/v1/surf/market/fear-greed` | $0.001 | — | Fear & Greed index history |
-| `/v1/surf/market/futures` | $0.001 | — | Futures market overview |
-| `/v1/surf/market/price` | $0.001 | `symbol` | Token price history |
-| `/v1/surf/market/etf` | $0.001 | `symbol` | Spot ETF flow history (BTC, ETH) |
-| `/v1/surf/market/options` | $0.001 | `symbol` | Options skew / IV / volume |
-| `/v1/surf/market/liquidation/exchange-list` | $0.005 | — | Liquidations by exchange |
-| `/v1/surf/market/liquidation/order` | $0.005 | — | Large liquidation orders |
-| `/v1/surf/market/liquidation/chart` | $0.005 | `symbol` | Liquidation chart over time |
-| `/v1/surf/market/onchain-indicator` | $0.005 | `symbol`, `metric` | NUPL, SOPR, MVRV, Puell, NVT |
-| `/v1/surf/market/price-indicator` | $0.005 | `indicator`, `symbol` | RSI, MACD, Bollinger, EMA |
+| `/v1/surf/market/ranking` | $0.0075 | — | Token ranking (market cap, volume, change) |
+| `/v1/surf/market/fear-greed` | $0.0075 | — | Fear & Greed index history |
+| `/v1/surf/market/futures` | $0.0075 | — | Futures market overview |
+| `/v1/surf/market/price` | $0.0075 | `symbol` | Token price history |
+| `/v1/surf/market/etf` | $0.0075 | `symbol` | Spot ETF flow history (BTC, ETH) |
+| `/v1/surf/market/options` | $0.0075 | `symbol` | Options skew / IV / volume |
+| `/v1/surf/market/liquidation/exchange-list` | $0.0075 | — | Liquidations by exchange |
+| `/v1/surf/market/liquidation/order` | $0.0075 | — | Large liquidation orders |
+| `/v1/surf/market/liquidation/chart` | $0.0075 | `symbol` | Liquidation chart over time |
+| `/v1/surf/market/onchain-indicator` | $0.0075 | `symbol`, `metric` | NUPL, SOPR, MVRV, Puell, NVT |
+| `/v1/surf/market/price-indicator` | $0.0075 | `indicator`, `symbol` | RSI, MACD, Bollinger, EMA |
 
 ### News
-| Path | Tier | Required params | What it returns |
+| Path | Price/call | Required params | What it returns |
 |---|---|---|---|
-| `/v1/surf/news/feed` | $0.001 | — | AI-curated crypto news feed |
-| `/v1/surf/news/detail` | $0.001 | `id` | Full article by ID |
+| `/v1/surf/news/feed` | $0.0075 | — | AI-curated crypto news feed |
+| `/v1/surf/news/detail` | $0.0075 | `id` | Full article by ID |
 
 ### Project (DeFi protocols + project profiles)
-| Path | Tier | Required params | What it returns |
+| Path | Price/call | Required params | What it returns |
 |---|---|---|---|
-| `/v1/surf/project/detail` | $0.001 | — | Aggregated project profile (token + DeFi + social) |
-| `/v1/surf/project/defi/metrics` | $0.001 | `metric` | Per-protocol DeFi metrics (TVL, fees, revenue) |
-| `/v1/surf/project/defi/ranking` | $0.001 | `metric` | DeFi protocol ranking |
+| `/v1/surf/project/detail` | $0.0075 | — | Aggregated project profile (token + DeFi + social) |
+| `/v1/surf/project/defi/metrics` | $0.0075 | `metric` | Per-protocol DeFi metrics (TVL, fees, revenue) |
+| `/v1/surf/project/defi/ranking` | $0.0075 | `metric` | DeFi protocol ranking |
 
 ### Token (on-chain analytics)
-| Path | Tier | Required params | What it returns |
+| Path | Price/call | Required params | What it returns |
 |---|---|---|---|
-| `/v1/surf/token/tokenomics` | $0.001 | — | Unlock schedule + vesting |
-| `/v1/surf/token/dex-trades` | $0.005 | `address` | DEX trade history |
+| `/v1/surf/token/tokenomics` | $0.0075 | — | Unlock schedule + vesting |
+| `/v1/surf/token/dex-trades` | $0.0075 | `address` | DEX trade history |
 
 ### Fund (VC + treasury intelligence)
-| Path | Tier | Required params | What it returns |
+| Path | Price/call | Required params | What it returns |
 |---|---|---|---|
-| `/v1/surf/fund/detail` | $0.001 | — | VC fund profile |
-| `/v1/surf/fund/portfolio` | $0.001 | — | VC fund portfolio holdings |
-| `/v1/surf/fund/ranking` | $0.001 | `metric` | Top VC funds ranking |
+| `/v1/surf/fund/detail` | $0.0075 | — | VC fund profile |
+| `/v1/surf/fund/portfolio` | $0.0075 | — | VC fund portfolio holdings |
+| `/v1/surf/fund/ranking` | $0.0075 | `metric` | Top VC funds ranking |
 
 ## How to choose
 
-- **"How's the market?"** → `market/fear-greed` + `market/ranking` (both $0.001). Cheap snapshot.
+- **"How's the market?"** → `market/fear-greed` + `market/ranking` (both $0.0075). Cheap snapshot.
 - **"What's BTC doing?"** → `market/price` for history, `exchange/price` for spot tick, `market/etf` for institutional flow.
 - **"Show me liquidations."** → `market/liquidation/chart` for time series, `market/liquidation/order` for whale events.
 - **"Technical signal on ETH"** → `market/price-indicator` with `indicator: "RSI"` (or MACD, BBANDS, EMA).
@@ -91,11 +96,13 @@ Call `BlockRun({ path: "/v1/surf/<endpoint>", method: "GET", params: { ... } })`
 
 ## Cost discipline
 
-- Most read endpoints are Tier 1 ($0.001). Burn freely.
-- Tier 2 ($0.005) endpoints carry depth, history, or fraud-signal data — use when the cheaper endpoint can't answer.
+- All tiers currently cost $0.0075/call. Estimate the total before a batch.
+- Tier 2 ($0.0075) endpoints carry depth, history, or fraud-signal data — use when that data is needed.
 - Avoid speculative multi-endpoint scans. Pick the right endpoint for the question; if unsure, ask the user one clarifying question first.
-- Report the cost on every call in your summary: "Pulled fear/greed history ($0.001). Index sits at 62 (greed)."
+- Report the cost on every call in your summary: "Pulled fear/greed history ($0.0075). Index sits at 62 (greed)."
 
 ## The user asked
 
 $ARGUMENTS
+
+Pricing reference: the account gateway currently lists Surf and Predexon service calls at $0.0075 per request. Confirm the current service quote before a batch; account Activity is the receipt, and wallet x402 quotes can also include payment-rail fees.

--- a/src/skills-bundled/surf-social/SKILL.md
+++ b/src/skills-bundled/surf-social/SKILL.md
@@ -15,9 +15,14 @@ argument-hint: <project, handle, or question>
 cost-receipt: true
 ---
 
+**Active billing:** {{billing_context}}
+
+
 You are running inside Franklin on **{{wallet_chain}}**. Use the `BlockRun` tool to call Surf's social endpoints. This is the canonical source for crypto-Twitter signal — mindshare scoring, KOL identification, and reply-graph analysis.
 
-**Chain note:** Surf currently settles x402 payments on **Base** only. If the user's active chain is `solana` and you hit a payment error, ask them to `/chain base` before retrying. The social data itself is chain-agnostic.
+**Account mode:** do not switch chains or fund a wallet for API errors. Check the key or account credits instead.
+
+**Chain note (wallet mode only):** Surf currently settles x402 payments on **Base** only. If the user's active chain is `solana` and you hit a payment error, ask them to `/chain base` before retrying. The social data itself is chain-agnostic.
 
 ## How to use
 
@@ -25,7 +30,7 @@ You are running inside Franklin on **{{wallet_chain}}**. Use the `BlockRun` tool
 
 ## Endpoint catalog
 
-### Project-level signal (Tier 2, $0.005)
+### Project-level signal (Tier 2, $0.0075)
 | Path | Required params | What it returns |
 |---|---|---|
 | `/v1/surf/social/detail` | — | Aggregated social analytics for a project |
@@ -33,13 +38,13 @@ You are running inside Franklin on **{{wallet_chain}}**. Use the `BlockRun` tool
 | `/v1/surf/social/smart-followers/history` | — | Smart-follower count history (high-signal accounts only) |
 | `/v1/surf/social/mindshare` | `q`, `interval` | Mindshare time series for a project (`q` = ticker or name, `interval` = `1d` / `7d` / `30d`) |
 
-### Tweet-level (Tier 1, $0.001)
+### Tweet-level (Tier 1, $0.0075)
 | Path | Required params | What it returns |
 |---|---|---|
 | `/v1/surf/social/tweets` | `ids` (comma-sep) | Fetch tweets by ID |
 | `/v1/surf/social/tweet/replies` | `tweet_id` | Replies to a specific tweet |
 
-### User-level (Tier 1, $0.001)
+### User-level (Tier 1, $0.0075)
 | Path | Required params | What it returns |
 |---|---|---|
 | `/v1/surf/social/user` | `handle` | Twitter user profile |
@@ -50,12 +55,12 @@ You are running inside Franklin on **{{wallet_chain}}**. Use the `BlockRun` tool
 
 ## How to choose
 
-- **"What's the market saying about $X?"** → `social/mindshare` with `q: "X", interval: "7d"` ($0.005). Read the trend, not the absolute number.
-- **"Who's the smart money following $X?"** → `social/smart-followers/history` ($0.005). Compare growth rate to baseline.
-- **"Top projects by attention right now"** → `social/ranking` ($0.005).
+- **"What's the market saying about $X?"** → `social/mindshare` with `q: "X", interval: "7d"` ($0.0075). Read the trend, not the absolute number.
+- **"Who's the smart money following $X?"** → `social/smart-followers/history` ($0.0075). Compare growth rate to baseline.
+- **"Top projects by attention right now"** → `social/ranking` ($0.0075).
 - **"Is @handle a real player?"** → `social/user` then `social/user/followers` (look at follower-to-following ratio + which smart accounts follow them).
-- **"What did @handle say recently?"** → `social/user/posts` ($0.001 each).
-- **"Show me the reply storm under tweet X"** → `social/tweet/replies` ($0.001).
+- **"What did @handle say recently?"** → `social/user/posts` ($0.0075 each).
+- **"Show me the reply storm under tweet X"** → `social/tweet/replies` ($0.0075).
 
 ## When NOT to use this skill
 
@@ -64,10 +69,12 @@ You are running inside Franklin on **{{wallet_chain}}**. Use the `BlockRun` tool
 
 ## Cost discipline
 
-- User-level reads are cheap ($0.001). Free to fan out across 5–10 handles when profiling.
-- Project-level signal is $0.005/call. One mindshare + one smart-followers call is usually enough to answer "is this thing real?".
+- User-level reads are cheap ($0.0075). Five to ten handles cost $0.0375–$0.075 before any payment-rail fees; keep the batch within the user's budget.
+- Project-level signal is $0.0075/call. One mindshare + one smart-followers call is usually enough to answer "is this thing real?".
 - Always include the cost in your summary.
 
 ## The user asked
 
 $ARGUMENTS
+
+Pricing reference: the account gateway currently lists Surf and Predexon service calls at $0.0075 per request. Confirm the current service quote before a batch; account Activity is the receipt, and wallet x402 quotes can also include payment-rail fees.

--- a/src/skills-bundled/trade-discussion/SKILL.md
+++ b/src/skills-bundled/trade-discussion/SKILL.md
@@ -12,6 +12,9 @@ argument-hint: <topic>
 cost-receipt: false
 ---
 
+**Active billing:** {{billing_context}}
+
+
 You are running inside Franklin on **{{wallet_chain}}**. This skill is the lightest of the three trading skills — no trade, no full strategy doc, just a short observation with enough structure to be useful later.
 
 ## Workflow
@@ -63,7 +66,7 @@ You are running inside Franklin on **{{wallet_chain}}**. This skill is the light
 
 - **`/trade-discussion`** — open-ended observation, hypothesis, "what if". Cheapest, least structured.
 - **`/trade-strategy`** — committed plan with entry/exit/sizing. Reach for this when an observation has hardened.
-- **`/trade-signal`** — the actual trade. Fires `TradingOpenPosition`, hits the wallet (paper trading) and the journal.
+- **`/trade-signal`** — the actual trade. Fires `TradingOpenPosition`, records a simulated fill (market-data calls may be billed) and the journal.
 
 ## The user said
 

--- a/src/skills-bundled/trade-signal/SKILL.md
+++ b/src/skills-bundled/trade-signal/SKILL.md
@@ -13,6 +13,9 @@ argument-hint: <symbol or thesis>
 cost-receipt: false
 ---
 
+**Active billing:** {{billing_context}}
+
+
 You are running inside Franklin on **{{wallet_chain}}**. This is paper trading — fills are simulated against a live mark — so the value is the discipline, not the dollars. Every trade entered through this skill carries a rationale that the journal scorer evaluates on five dimensions:
 
 | Dimension | Weight | Earned by |
@@ -27,7 +30,7 @@ Total is a 0–5 score, persisted with the trade and averaged across the last 10
 
 ## Workflow
 
-1. **Read the request.** The user's argument is below under "The user said". If it's a complete thesis (symbol + direction + reasoning + numbers), proceed to step 3. If anything's vague, ask **one** clarifying question — the cheapest call you have on the wallet is "tell me more before I burn $0.001 on a market quote."
+1. **Read the request.** The user's argument is below under "The user said". If it's a complete thesis (symbol + direction + reasoning + numbers), proceed to step 3. If anything's vague, ask **one** clarifying question — the cheapest step is "tell me more before I burn $0.001 on a market quote."
 
 2. **Optional context** — if you don't already have a recent quote, call `TradingMarket({ ticker, assetClass })` (free for crypto, $0.001 for stocks). For thesis support beyond price, the `/surf-market`, `/surf-chain`, or `/surf-social` skills can be invoked, each documenting their own endpoint costs.
 

--- a/src/skills-bundled/trade-strategy/SKILL.md
+++ b/src/skills-bundled/trade-strategy/SKILL.md
@@ -11,6 +11,9 @@ argument-hint: <topic or thesis>
 cost-receipt: false
 ---
 
+**Active billing:** {{billing_context}}
+
+
 You are running inside Franklin on **{{wallet_chain}}**. This skill captures *intent* before *action*. The user wants a written strategy, not an executed trade. Result: a markdown file under `~/.blockrun/notes/` that the user (and future Franklin sessions) can reference when the actual trade fires via `/trade-signal`.
 
 ## Workflow

--- a/src/skills/bootstrap.ts
+++ b/src/skills/bootstrap.ts
@@ -30,6 +30,7 @@ import { loadSkillsFromDir } from './loader.js';
 import { Registry } from './registry.js';
 import type { LoadError, LoadedSkill } from './types.js';
 import { BLOCKRUN_DIR } from '../config.js';
+import { accountMode, ACCOUNT_PORTAL } from '../payments/account.js';
 import { migrateLegacyLearnedSkills } from '../learnings/store.js';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -124,10 +125,16 @@ export function ensureLearnedSkillsDir(): string {
 
 export interface SkillVarSource {
   chain?: 'base' | 'solana';
+  authMode?: 'api-key' | 'wallet';
 }
 
 export function getSkillVars(src: SkillVarSource): Record<string, string> {
   const out: Record<string, string> = {};
-  if (src.chain) out.wallet_chain = src.chain;
+  const usesAccount = src.authMode ? src.authMode === 'api-key' : accountMode();
+  if (usesAccount) out.wallet_chain = 'account API (no payment chain)';
+  else if (src.chain) out.wallet_chain = src.chain;
+  out.billing_context = usesAccount
+    ? `Model, media and data calls use prepaid account credits. No payment wallet or chain switch is needed. Balance and activity: ${ACCOUNT_PORTAL}/dashboard; top up: ${ACCOUNT_PORTAL}/dashboard/credits. Local cost receipts are estimates. Never inspect or print the API key.`
+    : `Model, media and data calls use x402 wallet payments${src.chain ? ` on ${src.chain}` : ''}. Fund the selected payment wallet with USDC. A switch to account billing requires an explicit API key configuration.`;
   return out;
 }

--- a/src/tools/blockrun.ts
+++ b/src/tools/blockrun.ts
@@ -239,7 +239,7 @@ export const blockrunCapability: CapabilityHandler = {
   spec: {
     name: 'BlockRun',
     description:
-      'Call any BlockRun gateway endpoint. Signs an x402 USDC payment from the user wallet, retries on HTTP 402, and returns the response. ' +
+      'Call any BlockRun gateway endpoint using account API credits or the selected x402 wallet. Only wallet mode signs and retries payment challenges. ' +
       'Use this for crypto data (Surf — markets, on-chain, social), AI inference (chat / image / video / music), prediction markets, DeFi data, and any other API exposed under https://blockrun.ai/marketplace. ' +
       'For phone and voice, prefer the typed tools (ListPhoneNumbers, BuyPhoneNumber, RenewPhoneNumber, ReleasePhoneNumber, PhoneLookup, PhoneFraudCheck, VoiceCall, VoiceStatus) — they spell out cost, required fields, and the buy-number-first requirement. ' +
       'The path must start with "/v1/" or "/.well-known/". ' +

--- a/src/tools/blockrun.ts
+++ b/src/tools/blockrun.ts
@@ -1,3 +1,4 @@
+import { gatewayFetch as fetch, accountMode, pollAccountJob } from '../payments/account.js';
 /**
  * BlockRun primitive — the generic x402-paid gateway capability.
  *
@@ -163,7 +164,7 @@ async function callGateway(
     let response = await fetch(url, { method, signal: ctrl.signal, headers, body: payload });
 
     let paidUsd = 0;
-    if (response.status === 402) {
+    if (response.status === 402 && !accountMode()) {
       const signed = await signPayment(response, chain, url, resourceDescription);
       if (!signed) {
         return {
@@ -186,6 +187,7 @@ async function callGateway(
     // claim a paid amount the wallet didn't actually spend.
     if (!response.ok) paidUsd = 0;
 
+    response = await pollAccountJob(response, ctrl.signal);
     const raw = await response.text().catch(() => '');
     let parsed: Record<string, unknown> | unknown[] = {};
     try { parsed = raw ? JSON.parse(raw) : {}; } catch { /* leave as {} */ }
@@ -337,7 +339,7 @@ export const blockrunCapability: CapabilityHandler = {
       };
     }
 
-    const head = `BlockRun ${method} ${path} → ${fmtUsd(result.paidUsd)}${result.txHash ? ` · tx ${result.txHash.slice(0, 10)}…` : ''} · ${result.latencyMs}ms`;
+    const head = `BlockRun ${method} ${path} → ${accountMode() ? "account billing (see user.blockrun.ai)" : fmtUsd(result.paidUsd)}${result.txHash ? ` · tx ${result.txHash.slice(0, 10)}…` : ''} · ${result.latencyMs}ms`;
     const payload = typeof result.body === 'object' ? JSON.stringify(result.body, null, 2) : String(result.body);
     return {
       output: `${head}\n${payload}`,

--- a/src/tools/defillama.ts
+++ b/src/tools/defillama.ts
@@ -1,3 +1,4 @@
+import { gatewayFetch as fetch, accountMode } from '../payments/account.js';
 /**
  * DefiLlama capabilities — TVL, yield pools, protocol metadata, and token
  * prices via the BlockRun `/v1/defillama/*` endpoints. Each tool handles
@@ -59,7 +60,7 @@ async function getWithPayment<T>(path: string, ctx: ExecutionScope): Promise<T> 
       headers,
     });
 
-    if (response.status === 402) {
+    if (response.status === 402 && !accountMode()) {
       const signed = await signPayment(response, chain, endpoint);
       if (!signed) {
         throw new Error('Payment signing failed — check wallet balance');

--- a/src/tools/exa.ts
+++ b/src/tools/exa.ts
@@ -1,3 +1,4 @@
+import { gatewayFetch as fetch, accountMode } from '../payments/account.js';
 /**
  * Exa research capabilities — neural web search, cited Q&A, and batch
  * URL content fetch via the BlockRun `/v1/exa/*` endpoints.
@@ -73,7 +74,7 @@ async function postWithPayment<T>(
     });
 
     let settled = false;
-    if (response.status === 402) {
+    if (response.status === 402 && !accountMode()) {
       const paymentHeaders = await signPayment(response, chain, endpoint);
       if (!paymentHeaders) {
         throw new Error('Payment signing failed — check wallet balance');

--- a/src/tools/imagegen.ts
+++ b/src/tools/imagegen.ts
@@ -1,3 +1,4 @@
+import { gatewayFetch as fetch, accountMode } from '../payments/account.js';
 /**
  * Image Generation capability — generate images via BlockRun API.
  * Uses x402 payment on Solana or Base.
@@ -468,7 +469,7 @@ function buildExecute(deps: ImageGenDeps) {
     // re-presents the same authorization (the gateway settles on the
     // first completed poll, same contract as videogen.ts:251).
     let paymentHeaders: Record<string, string> | null = null;
-    if (response.status === 402) {
+    if (response.status === 402 && !accountMode()) {
       paymentHeaders = await signPayment(response, chain, endpoint);
       if (!paymentHeaders) {
         return { output: 'Payment failed. Check wallet balance with: franklin balance', isError: true };
@@ -707,7 +708,7 @@ async function saveImageDataToFile(
     const dlCtrl = new AbortController();
     const dlTimeout = setTimeout(() => dlCtrl.abort(), 30_000);
     try {
-      const imgResp = await fetch(imageData.url, { signal: dlCtrl.signal });
+      const imgResp = await globalThis.fetch(imageData.url, { signal: dlCtrl.signal });
       fs.writeFileSync(destPath, Buffer.from(await imgResp.arrayBuffer()));
     } finally {
       clearTimeout(dlTimeout);

--- a/src/tools/modal.ts
+++ b/src/tools/modal.ts
@@ -1,3 +1,4 @@
+import { gatewayFetch as fetch, accountMode } from '../payments/account.js';
 /**
  * Modal Sandbox capabilities — spin up GPU/CPU compute on Modal Labs via the
  * BlockRun gateway's x402-paid passthrough at /v1/modal/sandbox/{create, exec,
@@ -214,7 +215,7 @@ export async function postWithPayment(
     const payload = JSON.stringify(body);
     let response = await fetch(endpoint, { method: 'POST', signal: ctrl.signal, headers, body: payload });
 
-    if (response.status === 402) {
+    if (response.status === 402 && !accountMode()) {
       const paymentHeaders = await paymentSigner(response, chain, endpoint, resourceDescription);
       if (!paymentHeaders) {
         return { ok: false, status: 402, body: { error: 'payment signing failed' }, raw: '' };

--- a/src/tools/musicgen.ts
+++ b/src/tools/musicgen.ts
@@ -1,3 +1,4 @@
+import { gatewayFetch as fetch, accountMode, pollAccountJob } from '../payments/account.js';
 /**
  * Music Generation capability — generate ~3-minute MP3 tracks via the
  * BlockRun `/v1/audio/generations` endpoint. Uses x402 payment (Base
@@ -152,7 +153,7 @@ function buildExecute(deps: MusicGenDeps) {
         body,
       });
 
-      if (response.status === 402) {
+      if (response.status === 402 && !accountMode()) {
         const paymentHeaders = await signPayment(response, chain, endpoint);
         if (!paymentHeaders) {
           return { output: 'Payment failed. Check wallet balance with: franklin balance', isError: true };
@@ -165,6 +166,7 @@ function buildExecute(deps: MusicGenDeps) {
         });
       }
 
+      response = await pollAccountJob(response, ctx.abortSignal);
       if (!response.ok) {
         const errText = await response.text().catch(() => '');
         return {
@@ -189,7 +191,7 @@ function buildExecute(deps: MusicGenDeps) {
       // CDN URLs expire in ~24h — download NOW.
       const dlCtrl = new AbortController();
       const dlTimeout = setTimeout(() => dlCtrl.abort(), DOWNLOAD_TIMEOUT_MS);
-      const mp3Resp = await fetch(track.url, { signal: dlCtrl.signal });
+      const mp3Resp = await globalThis.fetch(track.url, { signal: dlCtrl.signal });
       clearTimeout(dlTimeout);
       if (!mp3Resp.ok) {
         return {

--- a/src/tools/phone.ts
+++ b/src/tools/phone.ts
@@ -1,3 +1,4 @@
+import { gatewayFetch as fetch, accountMode } from '../payments/account.js';
 /**
  * Phone number management — buy / list / renew / release / lookup wallet-
  * owned phone numbers via the BlockRun gateway `/v1/phone/*` endpoints.
@@ -72,7 +73,7 @@ async function postWithPayment<T>(
       body: bodyStr,
     });
 
-    if (response.status === 402) {
+    if (response.status === 402 && !accountMode()) {
       const paymentHeaders = await signPayment(response, chain, endpoint, 'Franklin phone');
       if (!paymentHeaders) throw new Error('Payment signing failed — check wallet balance');
       response = await fetch(endpoint, {

--- a/src/tools/phone.ts
+++ b/src/tools/phone.ts
@@ -231,7 +231,7 @@ export const buyPhoneNumberCapability: CapabilityHandler = {
       );
       return {
         output:
-          `## Number provisioned ($5 USDC charged)\n\n` +
+          `## Number provisioned (${accountMode() ? "account credits; see Activity at user.blockrun.ai" : "$5 USDC charged"})\n\n` +
           '```json\n' + JSON.stringify(res, null, 2) + '\n```',
       };
     } catch (err) {
@@ -279,7 +279,7 @@ export const renewPhoneNumberCapability: CapabilityHandler = {
       );
       return {
         output:
-          `## Lease renewed (+30 days, $5 USDC charged)\n\n` +
+          `## Lease renewed (+30 days, ${accountMode() ? "account credits; see Activity at user.blockrun.ai" : "$5 USDC charged"})\n\n` +
           '```json\n' + JSON.stringify(res, null, 2) + '\n```',
       };
     } catch (err) {
@@ -354,7 +354,7 @@ export const phoneLookupCapability: CapabilityHandler = {
       );
       return {
         output:
-          `## Phone lookup ($0.01 USDC charged)\n\n` +
+          `## Phone lookup (${accountMode() ? "account credits; see Activity at user.blockrun.ai" : "$0.01 USDC charged"})\n\n` +
           '```json\n' + JSON.stringify(res, null, 2) + '\n```',
       };
     } catch (err) {
@@ -391,7 +391,7 @@ export const phoneFraudCheckCapability: CapabilityHandler = {
       );
       return {
         output:
-          `## Fraud check ($0.05 USDC charged)\n\n` +
+          `## Fraud check (${accountMode() ? "account credits; see Activity at user.blockrun.ai" : "$0.05 USDC charged"})\n\n` +
           '```json\n' + JSON.stringify(res, null, 2) + '\n```',
       };
     } catch (err) {

--- a/src/tools/prediction.ts
+++ b/src/tools/prediction.ts
@@ -1,3 +1,4 @@
+import { gatewayFetch as fetch, accountMode } from '../payments/account.js';
 /**
  * PredictionMarket — unified access to Polymarket / Kalshi / Limitless /
  * Opinion / Predict.Fun / cross-platform / smart-money / wallet endpoints
@@ -105,7 +106,7 @@ async function getWithPayment<T>(path: string, query: Record<string, string | nu
   try {
     let response = await fetch(endpoint, { method: 'GET', signal: controller.signal, headers });
 
-    if (response.status === 402) {
+    if (response.status === 402 && !accountMode()) {
       const paymentHeaders = await signPayment(response, chain, endpoint);
       if (!paymentHeaders) {
         throw new Error('Payment signing failed — check wallet balance');

--- a/src/tools/realface.ts
+++ b/src/tools/realface.ts
@@ -1,3 +1,4 @@
+import { gatewayFetch as fetch, accountMode } from '../payments/account.js';
 /**
  * RealFace — enroll a real person's face as a reusable video avatar.
  *
@@ -212,7 +213,7 @@ async function actionEnroll(
 
   let res = await timedFetch(url, { method: 'POST', headers, body }, ctx);
   let paidUsd = 0;
-  if (res.status === 402) {
+  if (res.status === 402 && !accountMode()) {
     const signed = await signPayment(res, chain, url, `RealFace enrollment — "${name.slice(0, 32)}"`);
     if (!signed) return { output: 'RealFace enroll: payment signing failed. Check wallet balance with `franklin balance`.', isError: true };
     paidUsd = signed.amountUsd;
@@ -240,6 +241,7 @@ async function actionEnroll(
 }
 
 async function actionList(base: string, chain: 'base' | 'solana', ctx: ExecutionScope): Promise<CapabilityResult> {
+  if (accountMode()) return { output: 'Wallet RealFace listing requires a wallet address; account enroll/status requests work with the API key.', isError: true };
   const addr = await walletAddress(chain);
   const res = await timedFetch(`${base}/v1/wallet/${addr}/realfaces`, {
     method: 'GET',

--- a/src/tools/realface.ts
+++ b/src/tools/realface.ts
@@ -234,7 +234,7 @@ async function actionEnroll(
   }
   return {
     output:
-      `RealFace enrolled → $${paidUsd.toFixed(4)} · ${Date.now() - start}ms. ` +
+      `RealFace enrolled → ${accountMode() ? "account credits (see Activity at user.blockrun.ai)" : `$${paidUsd.toFixed(4)}`} · ${Date.now() - start}ms. ` +
       `Use the returned \`asset_id\` (ta_xxx) as \`real_face_asset_id\` on a VideoGen call with ` +
       `bytedance/seedance-2.0 or -fast for a real-person clip.${fence(raw)}`,
   };

--- a/src/tools/rpc.ts
+++ b/src/tools/rpc.ts
@@ -1,3 +1,4 @@
+import { gatewayFetch as fetch, accountMode } from '../payments/account.js';
 /**
  * Multi-chain RPC — read-only JSON-RPC across 40+ chains via the BlockRun
  * `/v1/rpc/{network}` endpoint (Tatum gateway). x402-paid against the user's
@@ -100,7 +101,7 @@ async function postRpcWithPayment(
       body: bodyStr,
     });
 
-    if (response.status === 402) {
+    if (response.status === 402 && !accountMode()) {
       const signed = await signPayment(response, chain, endpoint);
       if (!signed) {
         throw new Error('Payment signing failed — check wallet balance');

--- a/src/tools/surf.ts
+++ b/src/tools/surf.ts
@@ -82,7 +82,7 @@ const CHAIN_ENDPOINTS: SurfEndpoint[] = [
   { path: 'onchain/tx', method: 'GET', required: ['hash', 'chain'], desc: 'Transaction details by hash.' },
   { path: 'onchain/schema', method: 'GET', required: [], desc: 'Schema introspection for the SQL tables.' },
   { path: 'onchain/query', method: 'POST', required: [], desc: 'Structured chain query (POST body).' },
-  { path: 'onchain/sql', method: 'POST', required: [], desc: 'Raw SQL against 80+ indexed chain tables (POST body, Tier-3 $0.02).' },
+  { path: 'onchain/sql', method: 'POST', required: [], desc: 'Raw SQL against 80+ indexed chain tables (POST body, Tier-3 $0.0075).' },
   { path: 'token/tokenomics', method: 'GET', required: [], desc: 'Token supply / unlock / distribution.' },
   { path: 'token/dex-trades', method: 'GET', required: ['address'], desc: 'Recent DEX trades for a token.' },
   { path: 'token/holders', method: 'GET', required: ['address', 'chain'], desc: 'Top holders / concentration.' },
@@ -254,7 +254,7 @@ async function callSurf(
         isError: true,
       };
     }
-    const head = `Surf /v1/surf/${entry.path} → $${paidUsd.toFixed(4)} · ${Date.now() - start}ms`;
+    const head = `Surf /v1/surf/${entry.path} → ${accountMode() ? "account credits (see Activity at user.blockrun.ai)" : `$${paidUsd.toFixed(4)}`} · ${Date.now() - start}ms`;
     return { output: frameUntrusted('Surf web/API result', `${head}\n\n\`\`\`json\n${raw}\n\`\`\``) };
   } catch (err) {
     return { output: `${toolName} ${endpoint} error: ${(err as Error).message}`, isError: true };
@@ -277,8 +277,8 @@ function makeSurfTool(
     spec: {
       name,
       description:
-        `${blurb} Picks an endpoint from a fixed list and signs the x402 USDC payment from the wallet automatically — ` +
-        `you do not build paths or handle payment. Tier-1 $0.001, Tier-2 $0.005, Tier-3 $0.02.\n\nEndpoints:\n${endpointList}`,
+        `${blurb} Picks an endpoint from a fixed list and uses account API credits or signs the selected x402 wallet payment — ` +
+        `you do not build paths or handle payment. All tiers currently $0.0075/call; gateway billing is authoritative.\n\nEndpoints:\n${endpointList}`,
       input_schema: {
         type: 'object',
         properties: {

--- a/src/tools/surf.ts
+++ b/src/tools/surf.ts
@@ -1,3 +1,4 @@
+import { gatewayFetch as fetch, accountMode } from '../payments/account.js';
 /**
  * Surf — function-call tools for BlockRun's crypto data API.
  *
@@ -234,7 +235,7 @@ async function callSurf(
   try {
     let response = await fetch(url, { method: entry.method, signal: ctrl.signal, headers, body: payload });
     let paidUsd = 0;
-    if (response.status === 402) {
+    if (response.status === 402 && !accountMode()) {
       const signed = await signPayment(response, chain, url, resourceDescription);
       if (!signed) return { output: `${toolName} ${endpoint}: payment signing failed`, isError: true };
       paidUsd = signed.amountUsd;

--- a/src/tools/videogen.ts
+++ b/src/tools/videogen.ts
@@ -1,3 +1,4 @@
+import { gatewayFetch as fetch, accountMode } from '../payments/account.js';
 /**
  * Video Generation capability — generate short MP4 videos via the BlockRun
  * /v1/videos/generations endpoint. Uses x402 payment (Base or Solana).
@@ -269,7 +270,7 @@ function buildExecute(deps: VideoGenDeps) {
         body,
       });
 
-      if (response.status === 402) {
+      if (response.status === 402 && !accountMode()) {
         paymentHeaders = await signPayment(response, chain, endpoint);
         if (!paymentHeaders) {
           return { output: 'Payment failed. Check wallet balance with: franklin balance', isError: true };
@@ -305,7 +306,7 @@ function buildExecute(deps: VideoGenDeps) {
       ctx.abortSignal.removeEventListener('abort', submitAbort);
     }
 
-    if (!submitResult.poll_url || !paymentHeaders) {
+    if (!submitResult.poll_url || (!paymentHeaders && !accountMode())) {
       // Surface any diagnostic the body contained — same rationale as
       // imagegen.ts: "missing field" tells the agent nothing about
       // whether it was moderation, quota, or upstream model failure.
@@ -330,13 +331,13 @@ function buildExecute(deps: VideoGenDeps) {
       return {
         output:
           `Video generation did not complete within ${Math.round(POLL_MAX_WAIT_MS / 1000)}s. ` +
-          `No USDC was charged (settlement only fires on completion).`,
+          (accountMode() ? `Check job status and account usage before resubmitting.` : `No USDC was charged (settlement only fires on completion).`),
         isError: true,
       };
     }
     if (outcome.kind === 'failed') {
       return {
-        output: `Video generation failed upstream: ${outcome.error ?? 'unknown error'}. No USDC was charged.`,
+        output: `Video generation failed upstream: ${outcome.error ?? 'unknown error'}. ${accountMode() ? 'Check account usage in the portal.' : 'No USDC was charged.'}`,
         isError: true,
       };
     }
@@ -361,7 +362,7 @@ function buildExecute(deps: VideoGenDeps) {
       ctx.abortSignal.addEventListener('abort', dlAbort, { once: true });
       let vidResp: Response;
       try {
-        vidResp = await fetch(videoUrl, { signal: dlCtrl.signal });
+        vidResp = await globalThis.fetch(videoUrl, { signal: dlCtrl.signal });
       } finally {
         clearTimeout(dlTimeout);
         ctx.abortSignal.removeEventListener('abort', dlAbort);

--- a/src/tools/voice.ts
+++ b/src/tools/voice.ts
@@ -341,7 +341,7 @@ export const voiceCallCapability: CapabilityHandler = {
   },
   execute: async (input, ctx): Promise<CapabilityResult> => {
     if (typeof input.to !== 'string') return { output: 'to (E.164) required', isError: true };
-    if (typeof input.from !== 'string') return { output: 'from (wallet-owned E.164) required — use ListPhoneNumbers / BuyPhoneNumber', isError: true };
+    if (typeof input.from !== 'string') return { output: 'from (provisioned BlockRun E.164) required — use ListPhoneNumbers / BuyPhoneNumber', isError: true };
     if (typeof input.task !== 'string' || input.task.length < 10) {
       return { output: 'task required (10–4000 chars natural-language description)', isError: true };
     }

--- a/src/tools/voice.ts
+++ b/src/tools/voice.ts
@@ -1,3 +1,4 @@
+import { gatewayFetch as fetch, accountMode } from '../payments/account.js';
 /**
  * Outbound AI voice calls via Bland.ai through the BlockRun `/v1/voice/*`
  * gateway. Two tools:
@@ -98,7 +99,7 @@ async function postWithPayment<T>(
       body: bodyStr,
     });
 
-    if (response.status === 402) {
+    if (response.status === 402 && !accountMode()) {
       const paymentHeaders = await signPayment(response, chain, endpoint);
       if (!paymentHeaders) throw new Error('Payment signing failed — check wallet balance');
       response = await fetch(endpoint, {

--- a/src/tools/wallet.ts
+++ b/src/tools/wallet.ts
@@ -1,3 +1,4 @@
+import { accountMode, ACCOUNT_PORTAL } from '../payments/account.js';
 /**
  * Wallet capability — direct read of Franklin's wallet status.
  *
@@ -32,6 +33,7 @@ export function formatWalletReport(input: WalletReportInput): string {
 }
 
 async function execute(): Promise<CapabilityResult> {
+  if (accountMode()) return { output: `Account API mode. Balance, usage and credits: ${ACCOUNT_PORTAL}/dashboard. No payment wallet is required.` };
   const chain = loadChain();
   try {
     if (chain === 'solana') {

--- a/src/trading/providers/blockrun/client.ts
+++ b/src/trading/providers/blockrun/client.ts
@@ -1,3 +1,4 @@
+import { gatewayFetch as fetch, accountMode } from '../../../payments/account.js';
 /**
  * Shared BlockRun Gateway HTTP client + short-TTL cache.
  *
@@ -45,9 +46,9 @@ const cache = new Map<string, CacheEntry<unknown>>();
 
 export async function cached<T>(key: string, ttlMs: number, fn: () => Promise<T>): Promise<T> {
   const hit = cache.get(key) as CacheEntry<T> | undefined;
-  if (hit && hit.expiry > Date.now()) return hit.data;
+  if (!accountMode() && hit && hit.expiry > Date.now()) return hit.data;
   const data = await fn();
-  cache.set(key, { data, expiry: Date.now() + ttlMs });
+  if (!accountMode()) cache.set(key, { data, expiry: Date.now() + ttlMs });
   return data;
 }
 
@@ -87,7 +88,7 @@ export async function blockrunGet(
       recordFetch({ provider: 'blockrun', endpoint: opts.endpoint, ok: false, latencyMs });
       return { kind: 'not-found', message: `BlockRun Gateway 404 for ${path}` };
     }
-    if (res.status === 402) {
+    if (res.status === 402 && !accountMode()) {
       // Free-path client should never see a 402. If the Gateway starts
       // charging for an endpoint that was free, surface an actionable
       // error and let the caller migrate to `blockrunGetPaid`.
@@ -222,7 +223,7 @@ export async function blockrunGetPaid(
   };
   try {
     let res = await fetch(url, { headers, signal: ctrl.signal });
-    if (res.status === 402) {
+    if (res.status === 402 && !accountMode()) {
       try {
         const paid = await signGatewayPayment(res, chain, url);
         if (!paid) {

--- a/src/ui/app.tsx
+++ b/src/ui/app.tsx
@@ -746,7 +746,7 @@ function InputBox({ input, setInput, onSubmit, model, balance, chain, walletTail
             return balance;
           })()}
           {chain ? <Text>  ·  <Text color="magenta">{chain}</Text>{walletTail ? <Text dimColor>:{walletTail}</Text> : ''}</Text> : ''}
-          {sessionCost > 0.00001 ? <Text color="yellow">  -${sessionCost.toFixed(4)}</Text> : ''}
+          {sessionCost > 0.00001 ? <Text color="yellow">  {chain === "account" ? "~$" : "-$"}{sessionCost.toFixed(4)}</Text> : ''}
           {contextPct !== undefined && contextPct > 0 ? (() => {
             // Visual context bar: ▓▓▓▓▓▓░░░░ 75%
             const filled = Math.round(contextPct / 10);

--- a/test/api-key.local.mjs
+++ b/test/api-key.local.mjs
@@ -19,6 +19,33 @@ afterEach(()=>{globalThis.fetch=originalFetch;if(savedKey===undefined)delete pro
 const ctx=()=>({workingDir:process.cwd(),abortSignal:new AbortController().signal});
 const json=(data,status=200)=>new Response(JSON.stringify(data),{status,headers:{'content-type':'application/json'}});
 
+test('removing account configuration restores the original wallet request unchanged', async () => {
+ const {gatewayFetch}=await import('../dist/payments/account.js');
+ const seen=[];
+ globalThis.fetch=async(u,o)=>{seen.push([u,o]);return json({ok:true});};
+ await gatewayFetch('https://sol.blockrun.ai/api/v1/search', {headers:{'payment-signature':'fixture-wallet-proof'}});
+ assert.equal(String(seen[0][0]),'https://api.blockrun.ai/v1/search');
+ assert.equal(seen[0][1].headers.get('authorization'),`Bearer ${key}`);
+ assert.equal(seen[0][1].headers.get('payment-signature'),null);
+ delete process.env.BLOCKRUN_API_KEY;
+ const request=new Request('https://sol.blockrun.ai/api/v1/search',{method:'POST',body:'{}',headers:{'payment-signature':'fixture-wallet-proof'}});
+ await gatewayFetch(request);
+ assert.equal(seen[1][0],request);
+ assert.equal(seen[1][0].headers.get('payment-signature'),'fixture-wallet-proof');
+ assert.equal(seen[1][0].headers.get('authorization'),null);
+ assert.equal(seen[1][1],undefined);
+});
+
+test('malformed account environment stops before wallet or network access', async () => {
+ const {gatewayFetch}=await import('../dist/payments/account.js');
+ let calls=0;globalThis.fetch=async()=>{calls++;return json({ok:true});};
+ for(const invalid of ['', '  ', 'bad']){
+  process.env.BLOCKRUN_API_KEY=invalid;
+  await assert.rejects(()=>gatewayFetch('https://sol.blockrun.ai/api/v1/search'),/Invalid BLOCKRUN_API_KEY/);
+ }
+ assert.equal(calls,0);
+});
+
 test('shared account auth rewrites gateways, strips wallet headers and refuses other origins',async()=>{
  const {gatewayFetch}=await import('../dist/payments/account.js');
  const seen=[];globalThis.fetch=async(u,o)=>{seen.push([String(u),o]);return json({ok:true});};
@@ -102,4 +129,112 @@ test('VideoGen accepts first 202 without payment headers, polls, and downloads w
   assert.equal(url,'https://cdn.example/video.mp4');assert.equal(new Headers(o.headers).get('authorization'),null);return new Response(new Uint8Array([1,2,3]));
  };
  try{const result=await videoGenCapability.execute({prompt:'cat',output_path:'video.mp4',duration_seconds:5},{workingDir:dir,abortSignal:new AbortController().signal});assert.notEqual(result.isError,true,result.output);assert.ok(existsSync(join(dir,'video.mp4')));assert.equal(calls.filter(u=>u.endsWith('/videos/generations')).length,1);}finally{rmSync(dir,{recursive:true,force:true});}
+});
+
+// Public tool handlers against an in-memory gateway. These never place calls,
+// purchase phone numbers, enroll people, or provision cloud resources.
+const serviceCases = [
+ ['phone','phoneLookupCapability',{phone_number:'+12025550123'},'/v1/phone/lookup'],
+ ['phone','phoneFraudCheckCapability',{phone_number:'+12025550123'},'/v1/phone/lookup/fraud'],
+ ['phone','listPhoneNumbersCapability',{},'/v1/phone/numbers/list'],
+ ['phone','buyPhoneNumberCapability',{country:'US',area_code:'202'},'/v1/phone/numbers/buy'],
+ ['phone','renewPhoneNumberCapability',{phone_number:'+12025550123'},'/v1/phone/numbers/renew'],
+ ['phone','releasePhoneNumberCapability',{phone_number:'+12025550123'},'/v1/phone/numbers/release'],
+ ['voice','voiceCallCapability',{to:'+12025550123',from:'+12025550124',task:'Read the test message'},'/v1/voice/call'],
+ ['rpc','multiChainRpcCapability',{network:'solana',method:'getSlot'},'/v1/rpc/solana'],
+ ['surf','surfMarketCapability',{endpoint:'market/ranking'},'/v1/surf/market/ranking'],
+ ['surf','surfChainCapability',{endpoint:'onchain/sql',body:{query:'SELECT 1'}},'/v1/surf/onchain/sql'],
+ ['surf','surfSocialCapability',{endpoint:'social/user',params:{handle:'fixture'}},'/v1/surf/social/user'],
+ ['defillama','defiLlamaChainsCapability',{},'/v1/defillama/chains'],
+ ['realface','realFaceCapability',{action:'init',name:'fixture'},'/v1/realface/init'],
+ ['realface','realFaceCapability',{action:'status',group_id:'legacy_rf_123'},'/v1/realface/status'],
+ ['realface','realFaceCapability',{action:'enroll',group_id:'legacy_rf_123',name:'fixture',image_url:'https://example.com/fixture.png'},'/v1/realface/enroll'],
+ ['blockrun','blockrunCapability',{path:'/v1/audio/speech',method:'POST',body:{input:'hello'}},'/v1/audio/speech'],
+ ['blockrun','blockrunCapability',{path:'/v1/crypto/price/BTC-USD'},'/v1/crypto/price/BTC-USD'],
+ ['blockrun','blockrunCapability',{path:'/v1/pm/polymarket/markets'},'/v1/pm/polymarket/markets'],
+];
+for (const [module,name,input,path] of serviceCases) {
+ test(`account error contract ${name} ${path}`,async()=>{
+  const tool=(await import(`../dist/tools/${module}.js`))[name];
+  for(const status of [401,402,429]){
+   const calls=[];
+   globalThis.fetch=async(u,o)=>{
+    const url=new URL(u instanceof Request?u.url:String(u));calls.push(url.pathname);
+    assert.equal(url.origin,'https://api.blockrun.ai');assert.equal(url.pathname,path);
+    assert.equal(o.headers.get('authorization'),`Bearer ${key}`);
+    assert.equal(o.headers.get('payment-signature'),null);
+    return new Response(JSON.stringify({error:{message:key,code:'fixture_limit'}}),{status,headers:{'content-type':'application/json','payment-required':'must-not-sign','retry-after':'17'}});
+   };
+   const result=await tool.execute(input,ctx());
+   assert.equal(result.isError,true,JSON.stringify(result));
+   assert.ok(!JSON.stringify(result).includes(key));
+   assert.equal(calls.length,1,`${name}: request missing or retried: ${JSON.stringify(result)}`);
+  }
+ });
+}
+
+for(const kind of ['image','music']){
+ test(`${kind} tool creates once, polls with account auth, and downloads without it`,async()=>{
+  const tool=(await import(`../dist/tools/${kind}gen.js`))[`${kind}GenCapability`];
+  const dir=mkdtempSync(join(tmpdir(),`franklin-account-${kind}-`));
+  const endpoint=kind==='image'?'/v1/images/generations':'/v1/audio/generations';
+  const file=kind==='image'?'image.png':'music.mp3';
+  const urls=[];
+  globalThis.fetch=async(u,o)=>{
+   const url=String(u);urls.push(url);
+   if(url.includes('/models'))return json({data:[]});
+   if(url.endsWith(endpoint))return json({id:'fixture',status:'queued',poll_url:`/api${endpoint}/fixture`},202);
+   if(url.endsWith(`${endpoint}/fixture`)){
+    assert.equal(o.headers.get('authorization'),`Bearer ${key}`);
+    return json({status:'completed',data:[{url:`https://cdn.example/${file}`,duration_seconds:3}]});
+   }
+   assert.equal(url,`https://cdn.example/${file}`);
+   assert.equal(new Headers(o?.headers).get('authorization'),null);
+   return new Response(new Uint8Array([1,2,3]));
+  };
+  try{
+   const result=await tool.execute({prompt:'test fixture',output_path:file},{workingDir:dir,abortSignal:new AbortController().signal});
+   assert.notEqual(result.isError,true,result.output);assert.ok(existsSync(join(dir,file)));
+   assert.equal(urls.filter(u=>u.endsWith(endpoint)).length,1);
+  }finally{rmSync(dir,{recursive:true,force:true});}
+ });
+}
+
+for(const [module,name,input] of [
+ ['surf','surfMarketCapability',{endpoint:'market/ranking'}],
+ ['realface','realFaceCapability',{action:'enroll',group_id:'legacy_rf_123',name:'fixture',image_url:'https://example.com/fixture.png'}],
+ ['phone','phoneLookupCapability',{phone_number:'+12025550123'}],
+]){
+ test(`${name} success identifies account billing instead of zero cost or USDC settlement`,async()=>{
+  globalThis.fetch=async()=>json({data:[],asset_id:'ta_fixture'});
+  const tool=(await import(`../dist/tools/${module}.js`))[name];
+  const result=await tool.execute(input,ctx());
+  assert.notEqual(result.isError,true,result.output);
+  assert.match(result.output,/account|Activity/i);
+  assert.doesNotMatch(result.output,/\$0\.0000|USDC charged/);
+ });
+}
+
+
+for (const status of [502, 503, 504, 522, 524]) {
+ test(`account polling recovers an existing job after ${status}`, async () => {
+  const {pollAccountJob} = await import('../dist/payments/account.js');
+  const seen = [];
+  globalThis.fetch = async (url, options) => {
+   seen.push([String(url), options.method || 'GET']);
+   return seen.length === 1 ? json({error:{message:'temporary gateway failure'}}, status) : json({status:'completed',id:'existing'});
+  };
+  const result = await pollAccountJob(json({poll_url:'/v1/jobs/existing?token=signed'},202), undefined, 1);
+  assert.equal((await result.json()).status, 'completed');
+  assert.deepEqual(seen, Array(2).fill(['https://api.blockrun.ai/v1/jobs/existing?token=signed','GET']));
+ });
+}
+
+test('CLI help presents account credits and registration alongside wallets', async () => {
+ const {execFileSync} = await import('node:child_process');
+ const help = execFileSync(process.execPath, ['dist/index.js', '--help'], {encoding:'utf8'});
+ assert.match(help, /BlockRun API key/);
+ assert.match(help, /https:\/\/user\.blockrun\.ai/);
+ assert.match(help, /Solana or Base/);
+ assert.doesNotMatch(help, /No accounts\./);
 });

--- a/test/api-key.local.mjs
+++ b/test/api-key.local.mjs
@@ -1,0 +1,105 @@
+import { test, beforeEach, afterEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, existsSync, unwatchFile } from 'node:fs';
+import { tmpdir, homedir } from 'node:os';
+import { join } from 'node:path';
+import { once } from 'node:events';
+
+process.env.FRANKLIN_NO_AUDIT='1';
+process.env.FRANKLIN_NO_PERSIST='1';
+process.env.FRANKLIN_NO_PREFETCH='1';
+process.env.FRANKLIN_NO_EVAL='1';
+process.env.FRANKLIN_NO_ANALYZER='1';
+const key='brk_live_unit_test';
+const originalFetch=globalThis.fetch;
+const savedKey=process.env.BLOCKRUN_API_KEY;
+const savedBase=process.env.BLOCKRUN_API_BASE_URL;
+beforeEach(()=>{process.env.BLOCKRUN_API_KEY=key;delete process.env.BLOCKRUN_API_BASE_URL;});
+afterEach(()=>{globalThis.fetch=originalFetch;if(savedKey===undefined)delete process.env.BLOCKRUN_API_KEY;else process.env.BLOCKRUN_API_KEY=savedKey;if(savedBase===undefined)delete process.env.BLOCKRUN_API_BASE_URL;else process.env.BLOCKRUN_API_BASE_URL=savedBase;});
+const ctx=()=>({workingDir:process.cwd(),abortSignal:new AbortController().signal});
+const json=(data,status=200)=>new Response(JSON.stringify(data),{status,headers:{'content-type':'application/json'}});
+
+test('shared account auth rewrites gateways, strips wallet headers and refuses other origins',async()=>{
+ const {gatewayFetch}=await import('../dist/payments/account.js');
+ const seen=[];globalThis.fetch=async(u,o)=>{seen.push([String(u),o]);return json({ok:true});};
+ await gatewayFetch('https://sol.blockrun.ai/api/v1/search?q=x',{headers:{'PAYMENT-SIGNATURE':'remove','x-api-key':'placeholder'}});
+ assert.equal(seen[0][0],'https://api.blockrun.ai/v1/search?q=x');
+ assert.equal(seen[0][1].headers.get('authorization'),`Bearer ${key}`);
+ assert.equal(seen[0][1].headers.get('payment-signature'),null);
+ assert.equal(seen[0][1].redirect,'error');
+ await assert.rejects(()=>gatewayFetch('https://evil.example/job'),/origin/);
+ assert.equal(seen.length,1);
+});
+
+test('native ModelClient returns account 402 once without signing',async()=>{
+ const {ModelClient}=await import('../dist/agent/llm.js');
+ const {classifyAgentError}=await import('../dist/agent/error-classifier.js');
+ let count=0;globalThis.fetch=async()=>{count++;return json({error:{message:key}},402);};
+ const client=new ModelClient({apiUrl:'https://sol.blockrun.ai/api',chain:'solana'});
+ const chunks=[];for await(const chunk of client.streamCompletion({model:'anthropic/claude-sonnet-4.6',messages:[{role:'user',content:'hi'}],max_tokens:5,stream:false}))chunks.push(chunk);
+ assert.equal(count,1);
+ const error=chunks.find(c=>c.kind==='error');assert.equal(error.payload.status,402);assert.match(error.payload.message,/account credits/);assert.equal(classifyAgentError(error.payload.message).isTransient,false);assert.equal(client.getLastPaidUsd(),0);
+ assert.ok(!JSON.stringify(chunks).includes(key));
+});
+
+test('ModelClient streams account messages with tool events intact',async()=>{
+ const {ModelClient}=await import('../dist/agent/llm.js');
+ let seen;
+ globalThis.fetch=async(u,o)=>{seen=[String(u),o];return new Response('event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}}\n\nevent: message_stop\ndata: {"type":"message_stop"}\n\n',{headers:{'content-type':'text/event-stream'}});};
+ const client=new ModelClient({apiUrl:'https://blockrun.ai/api',chain:'base'});
+ const chunks=[];for await(const chunk of client.streamCompletion({model:'anthropic/claude-sonnet-4.6',messages:[{role:'user',content:'hi'}],max_tokens:5}))chunks.push(chunk);
+ assert.equal(seen[0],'https://api.blockrun.ai/v1/messages');assert.equal(seen[1].headers.get('authorization'),`Bearer ${key}`);assert.ok(chunks.some(c=>c.kind==='content_block_delta'));
+});
+
+test('Exa and Wallet tools support account mode without a wallet',async()=>{
+ const {exaAnswerCapability}=await import('../dist/tools/exa.js');
+ const {walletCapability}=await import('../dist/tools/wallet.js');
+ let count=0;globalThis.fetch=async(u,o)=>{count++;assert.equal(o.headers.get('authorization'),`Bearer ${key}`);return json({answer:'account answer',citations:[]});};
+ const result=await exaAnswerCapability.execute({query:'hi'},ctx());assert.notEqual(result.isError,true);assert.match(result.output,/account answer/);
+ const status=await walletCapability.execute({},ctx());assert.match(status.output,/Account API/);assert.equal(count,1);
+});
+
+test('shared POST preserves account quota errors and Retry-After',async()=>{
+ const {postWithPayment}=await import('../dist/payments/post-with-payment.js');
+ for(const status of [401,402,429]){
+ let count=0;globalThis.fetch=async()=>{count++;return new Response(JSON.stringify({error:{message:'fail',code:'account_error'}}),{status,headers:{'retry-after':'30','payment-required':'never-sign'}});};
+ const result=await postWithPayment('https://blockrun.ai/api/v1/phone/lookup',{},'test');assert.equal(result.status,status);assert.equal(result.ok,false);assert.equal(count,1);
+ }
+});
+
+test('account async polling authenticates GET and stops at completion',async()=>{
+ const {pollAccountJob}=await import('../dist/payments/account.js');
+ let count=0;globalThis.fetch=async(u,o)=>{count++;assert.equal(String(u),'https://api.blockrun.ai/v1/jobs/1');assert.equal(o.headers.get('authorization'),`Bearer ${key}`);return json({status:'completed',data:[{url:'https://cdn.example/result'}]});};
+ const result=await pollAccountJob(json({status:'queued',poll_url:'/api/v1/jobs/1'},202),undefined,1);assert.equal((await result.json()).status,'completed');assert.equal(count,1);
+ await assert.rejects(()=>pollAccountJob(json({poll_url:'https://evil.example/job'},202),undefined,1),/origin/);assert.equal(count,1);
+});
+
+test('proxy returns account 402 without wallet initialization or model fallback',async()=>{
+ const {createProxy}=await import('../dist/proxy/server.js');
+ let count=0;globalThis.fetch=async()=>{count++;return json({error:{message:'quota'}},402);};
+ const proxy=createProxy({port:0,apiUrl:'https://blockrun.ai/api',chain:'base',fallbackEnabled:true});
+ proxy.listen(0,'127.0.0.1');await once(proxy,'listening');
+ try{const result=await originalFetch(`http://127.0.0.1:${proxy.address().port}/v1/messages`,{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify({model:'anthropic/claude-sonnet-4.6',max_tokens:5,messages:[{role:'user',content:'hi'}]})});assert.equal(result.status,402);assert.match(await result.text(),/account credits/);assert.equal(count,1);}finally{proxy.closeAllConnections();await new Promise(r=>proxy.close(r));}
+});
+
+test('panel exposes account status, never the credential',async()=>{
+ const {createPanelServer}=await import('../dist/panel/server.js');
+ const server=createPanelServer(0);server.listen(0,'127.0.0.1');await once(server,'listening');
+ try{const result=await originalFetch(`http://127.0.0.1:${server.address().port}/api/wallet`);const value=await result.json();assert.equal(value.authMode,'api-key');assert.equal(value.balance,null);assert.equal(value.address,'');assert.ok(!JSON.stringify(value).includes(key));}finally{server.closeAllConnections();await new Promise(r=>server.close(r));}
+});
+
+after(()=>unwatchFile(join(homedir(), ".blockrun", "franklin-stats.json")));
+
+test('VideoGen accepts first 202 without payment headers, polls, and downloads without key forwarding',async()=>{
+ const {videoGenCapability}=await import('../dist/tools/videogen.js');
+ const dir=mkdtempSync(join(tmpdir(),'franklin-api-video-'));
+ const calls=[];
+ globalThis.fetch=async(u,o)=>{
+  const url=String(u);calls.push(url);
+  if(url.includes('/models'))return json({data:[]});
+  if(url.endsWith('/videos/generations'))return json({id:'job-1',status:'queued',poll_url:'/api/v1/videos/generations/job-1'},202);
+  if(url.endsWith('/job-1')){assert.equal(o.headers.get('authorization'),`Bearer ${key}`);return json({status:'completed',data:[{url:'https://cdn.example/video.mp4',duration_seconds:5}]});}
+  assert.equal(url,'https://cdn.example/video.mp4');assert.equal(new Headers(o.headers).get('authorization'),null);return new Response(new Uint8Array([1,2,3]));
+ };
+ try{const result=await videoGenCapability.execute({prompt:'cat',output_path:'video.mp4',duration_seconds:5},{workingDir:dir,abortSignal:new AbortController().signal});assert.notEqual(result.isError,true,result.output);assert.ok(existsSync(join(dir,'video.mp4')));assert.equal(calls.filter(u=>u.endsWith('/videos/generations')).length,1);}finally{rmSync(dir,{recursive:true,force:true});}
+});

--- a/test/skills.local.mjs
+++ b/test/skills.local.mjs
@@ -619,3 +619,19 @@ test('legacy flat ~/.blockrun/skills/<name>.md migrates to learned/<name>/SKILL.
     rmSync(fakeHome, { recursive: true, force: true });
   }
 });
+
+
+test('account skills identify account credit even with a saved Solana preference', () => {
+  const vars = getSkillVars({ chain: 'solana', authMode: 'api-key' });
+  assert.match(vars.wallet_chain, /account API/);
+  assert.match(vars.billing_context, /prepaid account credits/);
+  assert.match(vars.billing_context, /user.blockrun.ai\/dashboard\/credits/);
+  for (const name of ['budget-grill', 'surf-market', 'surf-chain', 'surf-social', 'phone-call']) {
+    const skill = loadBundledSkills().registry.lookup(name);
+    const rendered = substituteVariables(skill.skill.body, vars, 'customer acceptance');
+    assert.match(rendered, /prepaid account credits/, name);
+    assert.doesNotMatch(rendered, /\{\{billing_context\}\}/, name);
+  }
+  assert.equal(getSkillVars({ chain: 'base', authMode: 'wallet' }).wallet_chain, 'base');
+  assert.equal(getSkillVars({ chain: 'solana', authMode: 'wallet' }).wallet_chain, 'solana');
+});


### PR DESCRIPTION
Franklin can run with BLOCKRUN_API_KEY without creating a payment wallet. Shared account transport covers the agent, model catalog, proxy, media submission/polling, search and gateway data tools. Account failures retain status and never invoke x402 signing; credentials stay on the configured origin and are omitted from CDN downloads. Existing wallet billing and on-chain transactions keep their separate wallet requirements.

Accepted account jobs now recover from temporary polling errors using the same signed URL, without resubmitting paid creation requests. CLI help/setup/balance, panel, tool output and bundled skills distinguish account credits from wallet USDC. Account-mode tools no longer describe zero local wallet spending as a free call or falsely report USDC settlement. Agent instructions correctly distinguish the account gateway from Base and Solana wallet gateways.

README adds registration, keys, Credits and Activity, clarifies local estimates versus account receipts, documents complete poll URLs and wallet switching, and distinguishes this source checkout from the published npm release. Actual trades, wallet-owned listings, wallet-signed sync and marketplace payments retain their existing wallet boundaries.

Validation: 729 local tests pass, including 401/402/429 service contracts, native Messages/SSE, proxy/panel, media polling and credential-free downloads, billing descriptions, bundled skill variables and CLI help. Build and offline brand checks pass. Packed npm installation and CLI help work on Node 20.20.2; installed agent/tools also pass HTTP integration against merged Enterprise gateway source. Combined five-product integration: 72 requests with simulated debit/meter reconciliation. Account integration works with the existing SDK dependency.

Provider and balance fixtures are not live acceptance of every service. No real phone calls, phone-number purchases, identity enrollment or trades were executed in these tests. No package publication or deployment.
