### PR TITLE
feat: pay by BlockRun API key alongside the USDC wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,65 @@
 # Changelog
 
+## Franklin Agent 3.44.0 — a second way to pay, and the ledger that nearly went blind
+
+**You can now fund Franklin with a prepaid BlockRun API key instead of a USDC
+wallet.** Sign up at [user.blockrun.ai](https://user.blockrun.ai), top up, then:
+
+```bash
+franklin login brk_live_...
+```
+
+The wallet is still Franklin's identity — memory, the trading journal and goals
+are keyed to it, and it remains the route that needs nothing from us. The key is
+for people who would rather not hold crypto to try an agent.
+
+**Wallet users are untouched, structurally.** The two gateways share no auth: a
+bearer key sent to `blockrun.ai/api` is ignored and still 402s, and
+`api.blockrun.ai` 401s with no x402 fallback. With no key configured Franklin
+resolves the same host and the same headers it always did — asserted per chain
+by test, not by inspection. Both can be configured at once; the key wins, and
+`--wallet` forces the wallet back for a single run.
+
+**The hard part was accounting, not routing.** The key gateway settles silently
+and returns *no charge amount* — not in `payment-response`, not in a header, not
+in the body. Franklin derives its entire ledger from the 402 handshake:
+
+```ts
+// before — src/tools/exa.ts
+if (!settled) return; // free/already-paid (200-first) path — no charge to record
+```
+
+`settled` is false for two very different things: a genuinely free call, and
+every API-key call. So every paid call in key mode would have recorded **$0**,
+silently disabling `--max-spend`, `PreSpend` hooks and every budget in the
+product. Paid calls are now priced from BlockRun's published rate card at
+`/.well-known/x402`, and each row is tagged exact or estimated.
+
+| | wallet | API key |
+|---|---|---|
+| `SurfMarket` | $0.0085 settled, exact | $0.0085 catalog, estimated |
+| `ExaSearch` | $0.007 settled, exact | $0.007 Exa-reported, exact |
+| chat | amount the wallet paid | `estimateCost()` from returned tokens |
+
+Estimates lean high on purpose: the x402 rate card carries a 5% margin and
+$0.001 per call that key mode does not charge. Over-counting is the safe side of
+a spend ceiling. `franklin stats` marks estimated totals with `~` and reports the
+estimated portion separately, and `franklin balance` refuses to invent a credit
+balance it cannot read.
+
+**A bug the proxy only revealed under live traffic.** Node lowercases a proxied
+client's `authorization`; `gatewayHeaders()` returns the canonical
+`Authorization`. A plain object held both, `fetch` sent two, the gateway read the
+client's — and every proxied call 401'd. `applyGatewayAuth()` strips every case
+variant before adding ours.
+
+**`brk_` keys are now redacted.** The secret redactor covered GitHub, Anthropic,
+OpenAI, AWS, Slack and Stripe but had no BlockRun pattern, so a key could reach
+transcripts and `franklin logs`.
+
+Solana leads Base throughout the CLI copy and README, matching the code default
+`loadChain()` has used for some time.
+
 ## Franklin Agent 3.43.1 — a guard that only runs on the happy path is not a guard
 
 **A vision request could fall back onto a model that cannot read images, and

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 
 <p>
   <a href="#quick-start">Quick&nbsp;start</a> ·
+  <a href="#two-ways-to-pay">Two&nbsp;ways&nbsp;to&nbsp;pay</a> ·
   <a href="#franklin-desktop-beta">Desktop</a> ·
   <a href="#yopo">YOPO</a> ·
   <a href="#a-new-category">Category</a> ·
@@ -44,7 +45,9 @@
 
 ## The pitch in one paragraph
 
-Franklin Agent is an **autonomous economic agent** — an AI that holds a USDC wallet and spends it to get real work done, with **trading as its flagship arena**. It buys live market data, proposes trade plans you approve before a cent moves, pursues long-running goals across sessions, keeps a wallet-bound trading journal, and picks the best model per task from 55+ providers. You state an outcome and set a budget. Franklin Agent decides what to call, what to pay for, and when to stop. Every paid action routes through the [x402](https://x402.org) micropayment protocol and settles against your own wallet. No subscriptions. No API keys. No account. The wallet is the identity.
+Franklin Agent is an **autonomous economic agent** — an AI that holds a USDC wallet and spends it to get real work done, with **trading as its flagship arena**. It buys live market data, proposes trade plans you approve before a cent moves, pursues long-running goals across sessions, keeps a wallet-bound trading journal, and picks the best model per task from 55+ providers. You state an outcome and set a budget. Franklin Agent decides what to call, what to pay for, and when to stop. No subscriptions, no seats, no rate limits.
+
+Funding it is your choice. Fund a **USDC wallet** and every paid action routes through the [x402](https://x402.org) micropayment protocol, settling on-chain against a wallet only you control — no signup, no account, the wallet is the identity. Or top up a **prepaid balance** at [user.blockrun.ai](https://user.blockrun.ai) and hand Franklin an API key. Same models, same tools, same agent. See [Two ways to pay](#two-ways-to-pay).
 
 Built by the [BlockRun](https://blockrun.ai) team. Apache-2.0. TypeScript. Ships as one npm package.
 
@@ -67,12 +70,18 @@ npm install -g @blockrun/franklin
 # 2. Run (free — uses NVIDIA Nemotron & Qwen3 Coder out of the box)
 franklin
 
-# 3. (optional) Fund a wallet to unlock Sonnet, Opus, GPT, Gemini, Grok, + paid APIs
-franklin setup base        # or: franklin setup solana
+# 3. (optional) Unlock Sonnet, Opus, GPT, Gemini, Grok + every paid API.
+#    Pick ONE — a USDC wallet, or a prepaid API key.
+
+#    a) Wallet — no signup, no account
+franklin setup solana      # or: franklin setup base
 franklin balance           # show address + USDC balance
+
+#    b) API key — sign up and top up at https://user.blockrun.ai
+franklin login brk_live_...
 ```
 
-That's it. Zero signup, zero credit card, zero phone verification. Send **$5 of USDC** to the wallet and you've unlocked every frontier model and every paid tool in the BlockRun gateway.
+Either route unlocks the same thing: **$5** buys you every frontier model and every paid tool in the BlockRun gateway. The wallet route needs zero signup, zero credit card, zero phone verification. The key route needs an account but no crypto.
 
 **No global install? Just run it directly** — no permissions, no `-g`:
 
@@ -141,6 +150,81 @@ The stable beta currently runs the Franklin agent. Team Mode and Studio adapters
 for additional agent CLIs are being developed separately and are not included in
 this release. See the [Desktop guide](apps/desktop/README.md) for development and
 packaging instructions.
+
+---
+
+## Two ways to pay
+
+Franklin needs money to work — it buys model calls, market data, search and media
+generation on your behalf. There are two ways to give it that money, and they are
+interchangeable. Everything else about the agent is identical.
+
+| | **USDC wallet** (x402) | **API key** (prepaid credit) |
+| --- | --- | --- |
+| Setup | `franklin setup solana` | Sign up, top up, `franklin login brk_...` |
+| Account required | No | Yes |
+| Crypto required | Yes — USDC on Solana or Base | No — top up with a card |
+| Settlement | On-chain, per call, via [x402](https://x402.org) | Against a prepaid balance |
+| Gateway | `sol.blockrun.ai` / `blockrun.ai` | `api.blockrun.ai` |
+| Where the money lives | A wallet only you hold the key to | Your BlockRun account |
+| Spend visibility | `franklin stats` — exact settled amounts | [Dashboard](https://user.blockrun.ai/dashboard) — see the note below |
+
+**The wallet is still Franklin's identity.** Memory, the trading journal and goals are
+keyed to it, and the wallet route is the one that needs nothing from us — no signup, no
+KYC, no account to suspend. The API key exists because not everyone wants to hold crypto
+to try an agent.
+
+### Getting an API key
+
+1. Sign up at **[user.blockrun.ai](https://user.blockrun.ai)**.
+2. Top up your balance from the dashboard.
+3. Create a key — it looks like `brk_live_...`.
+4. Give it to Franklin:
+
+```bash
+franklin login brk_live_...     # verifies the key, then stores it at ~/.blockrun/api-key (0600)
+franklin login                  # show the active pay mode without changing it
+franklin logout                 # remove the key and fall back to the wallet
+```
+
+Or set it in the environment instead, which takes precedence over the stored key and is
+the right choice for CI and servers:
+
+```bash
+export BLOCKRUN_API_KEY=brk_live_...
+```
+
+### Running both
+
+You can have a wallet **and** a key configured at once. The key wins by default. To spend
+from the wallet for a single run, add `--wallet` to any command:
+
+```bash
+franklin --wallet                 # this session pays from the wallet
+franklin balance --wallet         # show the wallet balance, not the key status
+```
+
+If the key is rejected, or a tool needs an endpoint the key gateway does not serve,
+Franklin falls back to the wallet for that call and tells you. It never falls back on a
+malformed request — a bad call is never retried with your USDC.
+
+### One honest caveat about spend tracking
+
+In wallet mode every charge is exact: the gateway states the price in the x402 handshake
+and Franklin records the amount that actually settled.
+
+In API-key mode the gateway settles silently against your balance and **returns no charge
+amount**. Franklin prices those calls locally from BlockRun's published x402 rate card, so
+`--max-spend`, `PreSpend` hooks and budgets all keep working — but the figures are
+estimates, and they lean high. The x402 rate card includes a 5% margin and a $0.001
+per-transaction fee that key mode does not charge (key mode bills provider list price;
+the fee is taken when you top up). Expect Franklin's local tally to read a few percent
+above what the dashboard shows.
+
+Over-counting is the safe direction for a spend ceiling, and Franklin is explicit about
+it: `franklin stats` marks estimated totals with `~` and reports the estimated portion
+separately, and `franklin balance` will not invent a credit balance it cannot read. For
+the authoritative number, use the [dashboard](https://user.blockrun.ai/dashboard).
 
 ---
 
@@ -352,7 +436,7 @@ No single model is best at everything. Sonnet writes better code, Gemini handles
 
 ### 🔐 &nbsp;Wallet is identity
 
-No email. No phone. No KYC. Your Base or Solana address is your account — portable, permissionless, global. API keys require US banking and account approval. A wallet requires only USDC.
+No email. No phone. No KYC. Your Solana or Base address is your account — portable, permissionless, global. A wallet requires only USDC. (Prefer an account and a card? [Two ways to pay](#two-ways-to-pay) — the key route exists, it just is not the one that makes the agent sovereign.)
 
 </td>
 </tr>
@@ -467,7 +551,7 @@ Core is workflow-agnostic. Add new verticals without touching the loop. Discover
 │  <!-- br:models.chatVisible -->66<!-- /br:models.chatVisible --> LLMs · CoinGecko · Search · Image APIs · paid services  │
 ├──────────────────────────────────────────────────────────────┤
 │  x402 Micropayment Protocol                                  │
-│  HTTP 402 · USDC on Base & Solana · signed payment payloads  │
+│  HTTP 402 · USDC on Solana & Base · signed payment payloads  │
 └──────────────────────────────────────────────────────────────┘
                             │
                             ▼
@@ -518,13 +602,13 @@ src/
 
 ## Free tier, for real
 
-Start with **zero dollars**. Franklin defaults to free NVIDIA models that need no wallet funding.
+Start with **zero dollars**. Franklin defaults to free NVIDIA models that need **no wallet and no API key** — nothing to fund, nothing to sign up for.
 
 ```bash
 franklin --model free
 ```
 
-When you fund the wallet, Franklin gets more purchasing power: Sonnet, Opus, GPT, Gemini, Grok, and paid tools like Exa, DALL-E, and CoinGecko Pro.
+Once you fund it — [either way](#two-ways-to-pay) — Franklin gets more purchasing power: Sonnet, Opus, GPT, Gemini, Grok, and paid tools like Exa, image generation, and live market data.
 
 ---
 

--- a/apps/desktop/src/components/WalletPanel.tsx
+++ b/apps/desktop/src/components/WalletPanel.tsx
@@ -44,6 +44,23 @@ export function WalletPanel({ usage }: { usage: Usage }) {
       <div className="try-wallet-inner">
         <h2 className="try-tools-h">{t.walletTitle}</h2>
 
+        {wallet?.payMode === "api-key" && (
+          // The wallet card below still renders an address and a USDC balance.
+          // Neither is what pays in this mode, and the prepaid credit balance is
+          // not readable from here, so say so plainly rather than let the number
+          // read as the budget.
+          <section className="try-wallet-network-card">
+            <div>
+              <strong>Paying by API key{wallet.apiKeyMasked ? ` · ${wallet.apiKeyMasked}` : ""}</strong>
+              <small>
+                Spend comes out of your prepaid balance, not the wallet below. Franklin cannot
+                read that balance — check it at user.blockrun.ai/dashboard. Run `franklin logout`
+                in a terminal to go back to paying from the wallet.
+              </small>
+            </div>
+          </section>
+        )}
+
         <section className="try-wallet-network-card">
           <div><strong>Payment network</strong><small>Franklin keeps a separate local wallet for each network. Switching restarts the local agent, never exports a key.</small></div>
           <div className="try-wallet-network-options" role="group" aria-label="Payment network">

--- a/apps/desktop/src/lib/wire.ts
+++ b/apps/desktop/src/lib/wire.ts
@@ -186,6 +186,15 @@ export interface WalletInfo {
   address: string;
   chain: "base" | "solana";
   balanceUsd?: number;
+  /**
+   * Which credential actually pays. In "api-key" mode the wallet below still
+   * exists and still holds USDC, but spend comes out of a prepaid balance the
+   * desktop cannot read — so the balance must not be presented as the budget.
+   * Absent on older CLIs; treat that as "wallet".
+   */
+  payMode?: "wallet" | "api-key";
+  /** e.g. `brk_live_H4Oz…QBW5`. Only set in api-key mode. */
+  apiKeyMasked?: string;
 }
 
 export interface ModelInfo {

--- a/docs/plans/2026-09-05-api-key-auth-design.md
+++ b/docs/plans/2026-09-05-api-key-auth-design.md
@@ -1,0 +1,335 @@
+# API-key auth alongside the wallet — design
+
+**Date:** 2026-09-05
+**Status:** proposed
+**Scope:** `@blockrun/franklin` (this repo) + README. Gateway-side asks are listed but out of repo scope.
+
+---
+
+## 1. Why
+
+Today Franklin can only pay one way: sign an x402 payment with a local USDC wallet on
+Base or Solana. That is the product's identity ("the AI agent with a wallet") and it
+stays. But it also gates the whole funnel behind "create a wallet, bridge USDC, fund
+it" — which loses every user who just wants to paste a key and start.
+
+BlockRun already runs a second, prepaid-credit gateway that speaks plain
+`Authorization: Bearer brk_live_…`. This design wires Franklin to it as a **second
+payment mode**, not a replacement, and rewrites the README so people know where to
+sign up and top up.
+
+---
+
+## 2. Established facts (probed 2026-09-05, not assumed)
+
+### 2.1 Two independent gateways
+
+| | Wallet mode | API-key mode |
+| --- | --- | --- |
+| Host | `blockrun.ai/api` (Base) / `sol.blockrun.ai/api` (Solana) | `api.blockrun.ai` |
+| Path shape | `{host}/v1/…` where host ends in `/api` | `{host}/v1/…`, **no `/api` segment** |
+| Auth | x402 `PAYMENT-SIGNATURE` header, per request | `Authorization: Bearer brk_live_…` |
+| Settlement | on-chain USDC, per call | prepaid credit balance |
+| Chain | Base or Solana | **none** — chain is not a concept here |
+
+They do not cross-authenticate:
+
+- A `Bearer brk_live_…` sent to `blockrun.ai/api/v1/chat/completions` is **ignored** —
+  still `402 Payment Required` with x402 requirements.
+- `api.blockrun.ai` with a bad key **or with no key at all** returns
+  `401 {"code":"invalid_api_key"}`. There is no x402 fallback on that host.
+- `api.blockrun.ai/api/v1/…` returns `404 {"code":"wrong_host"}` — the `/api` prefix
+  must be dropped, not kept.
+- The dashboard is a third host, `user.blockrun.ai`.
+
+This mutual isolation is what makes the feature safe: **an existing wallet user who
+never sets a key sees byte-identical behaviour.**
+
+### 2.2 Endpoint coverage on the key gateway — effectively complete
+
+All 33 gateway paths Franklin actually calls were probed with the live key. Every one
+routes (returning parameter-validation errors, not routing errors):
+
+`/v1/chat/completions`, `/v1/messages`, `/v1/models`, `/v1/images/generations`,
+`/v1/images/image2image`, `/v1/videos/generations`, `/v1/audio/generations`,
+`/v1/voice/call`, `/v1/exa/{search,answer,contents}`, `/v1/search`, `/v1/surf/**`,
+`/v1/crypto|fx|commodity|usstock/price/*`, `/v1/rpc/*`, `/v1/zerox/**`,
+`/v1/defillama/*`, `/v1/modal/sandbox/*`, `/v1/phone/*`, `/v1/pm/**`,
+`/v1/polymarket/fund`, `/v1/onramp/token`, `/v1/health/overview`.
+
+Four paths return `unsupported_endpoint` — `/v1/stocks/price/*`, `/v1/image/generate`,
+`/v1/x/search`, `/v1/wallet/balance`. **These are 404 on the x402 gateway too**
+(verified on both `blockrun.ai` and `sol.blockrun.ai`), so they are dead references in
+`src/`, not a coverage gap. They should be removed in a separate cleanup, and are
+explicitly not this change's problem.
+
+Live 200s confirmed end-to-end on the key: chat completion, Exa neural search,
+Grok live search, Polymarket markets, Modal sandbox create, phone number list.
+
+### 2.3 The blocking problem — the key gateway reports no charge
+
+A successful API-key call returns exactly these accounting-relevant headers:
+
+```
+payment-response: {"success":true,"transaction":"","network":"credit","payer":"pilot"}
+x-settlement-async: true
+x-blockrun-request-id: <uuid>
+```
+
+There is **no amount anywhere** — not in `payment-response`, not in a dedicated header,
+not in the body (except where the upstream provider happens to include one, e.g. Exa's
+`costDollars`). And `x-settlement-async: true` means the ledger entry lands after the
+response.
+
+Franklin's entire spend ledger is derived from the 402 handshake. Representative
+patterns in `src/`:
+
+```ts
+// src/tools/exa.ts:108
+if (!settled) return; // free/already-paid (200-first) path — no charge to record
+
+// src/tools/surf.ts:246 — paidUsd is only ever assigned inside the 402 branch
+if (!response.ok) paidUsd = 0;
+recordUsage(`${toolName}:${entry.path}`, 0, 0, paidUsd, Date.now() - start);
+```
+
+`src/tools/rpc.ts`, `src/tools/defillama.ts` and `src/tools/blockrun.ts` follow the same
+shape. Since API-key mode never produces a 402, **`paidUsd` stays `0` and every paid
+call records `$0`**. Downstream, that silently breaks:
+
+- `franklin stats` / the panel Audit tab — all spend reads zero
+- the `--max-spend` session ceiling — never trips, so an autonomous run has no cap
+- `PreSpend` / `PostSpend` hooks — `estimatedUsd` is null or zero, so user guardrails
+  do not fire
+- budget-bound content generation in `src/content/`
+- trade-plan cost lines
+- reconciliation against `user.blockrun.ai` — Franklin says $0, the dashboard says the
+  real number
+
+This is the single largest risk in the change and is addressed in §4.
+
+### 2.4 No credit-balance endpoint is exposed to the key
+
+`/v1/credits`, `/v1/key`, `/v1/usage`, `/v1/account`, `/v1/me` all return
+`unsupported_endpoint`; `/v1/balance` exists but takes an on-chain `address` (it is the
+wallet-balance endpoint, not a credit endpoint). So `franklin balance` cannot show a
+credit balance today — see §7 for the gateway-side ask and §5.5 for the interim
+behaviour.
+
+### 2.5 Solana is already the code default
+
+`loadChain()` in `src/config.ts` already returns `'solana'` unless the user has a Base
+wallet and no Solana wallet (a deliberate no-strand heuristic). The Base-first ordering
+that remains is in **docs, the README, and setup copy**, e.g.
+`franklin setup base        # or: franklin setup solana`.
+
+### 2.6 `brk_live_` is not redacted
+
+`src/agent/secret-redact.ts` covers GitHub, Anthropic, OpenAI, AWS, Google, Slack,
+Stripe, Twilio and raw private keys — but has no `brk_` pattern. Once keys exist in the
+product, an unredacted key can reach transcripts, logs and `franklin logs` output.
+Must be fixed in the same change.
+
+---
+
+## 3. Decisions taken
+
+1. **Precedence:** API key wins when present; wallet is the fallback. A key that is
+   invalid, or an endpoint the key gateway does not serve, falls back to the x402
+   wallet path rather than hard-failing.
+2. **Key entry:** all four of — `BLOCKRUN_API_KEY` env var, `franklin login <key>`
+   persisting to `~/.blockrun/api-key`, a step in the first-run setup wizard, and a
+   field in the desktop panel.
+3. **README framing:** two parallel on-ramps, wallet remains the primary narrative.
+   The absolute claim "No API keys. No account." is removed.
+
+---
+
+## 4. Architecture
+
+### 4.1 One resolver, not 43 edits
+
+Every gateway caller in `src/` already funnels through the same two lines:
+
+```ts
+const chain = loadChain();
+const apiUrl = API_URLS[chain];   // ends in /api
+// … fetch(`${apiUrl}/v1/…`)
+```
+
+So the change is a new module, `src/payments/auth-mode.ts`, exposing:
+
+```ts
+export type PayMode =
+  | { kind: 'key'; apiBase: 'https://api.blockrun.ai'; key: string }
+  | { kind: 'wallet'; apiBase: string; chain: Chain };
+
+export function resolvePayMode(): PayMode;      // cached per process
+export function gatewayHeaders(m: PayMode): Record<string, string>;
+export function invalidateKey(): void;          // on 401, demote to wallet for the process
+```
+
+`resolvePayMode()` order: `BLOCKRUN_API_KEY` → `~/.blockrun/api-key` → wallet mode via
+`loadChain()`. Callers replace `API_URLS[chain]` with `resolvePayMode().apiBase` and
+merge `gatewayHeaders(mode)` into their existing header object. Because the key host
+serves `/v1/…` at the root and `API_URLS[chain]` ends in `/api`, the concatenation
+`${apiBase}/v1/…` is correct in both modes with no per-call-site branching.
+
+**One exception:** `src/gateway-models.ts:149` does
+`API_URLS[chain].replace(/\/api$/, '')` to reach a non-`/v1` path. That regex is a
+no-op on `https://api.blockrun.ai` and must be reviewed by hand.
+
+### 4.2 Fallback on 401 / unsupported endpoint
+
+`postWithPayment()` in `src/payments/post-with-payment.ts` and the streaming path in
+`src/agent/llm.ts` gain one branch:
+
+- key mode, response is `401 invalid_api_key` → warn once, `invalidateKey()`, retry the
+  whole request against the wallet gateway. Never retry a second time.
+- key mode, response is `404 unsupported_endpoint` → retry on the wallet gateway for
+  that call only; do not demote the process.
+- key mode, any other status → surface as-is. No fallback on 400/402/5xx, so a bad
+  request does not silently spend wallet USDC.
+
+### 4.3 Cost accounting in key mode
+
+Franklin already owns local list prices — `MODEL_PRICING` / `estimateCost()` in
+`src/pricing.ts`, `perImageUsd` in `imagegen.ts`, `fallbackUsd` in `exa.ts`. The fix
+generalises that: **when no 402 occurred, price the call locally instead of recording
+zero.** Priority per call:
+
+1. a gateway-reported charge, if the response carries one (Exa `costDollars`, and any
+   future charge header — see §7)
+2. `estimateCost(model, promptTokens, completionTokens)` for token-metered endpoints,
+   using the `usage` block the key gateway does return
+3. the tool's own list-price constant for flat-rate endpoints
+
+Every recorded row is tagged with its provenance so the audit trail never claims more
+precision than it has — `exact` (settled x402 or gateway-reported) vs `estimated`
+(locally priced). `franklin stats` and the panel Audit tab render estimated rows with a
+`~` prefix, and `franklin stats` grows a one-line footer in key mode pointing at
+`user.blockrun.ai/dashboard` as the source of truth.
+
+This keeps `--max-spend`, `PreSpend` hooks and content budgets functional in key mode.
+They operate on an estimate, and that is stated plainly rather than hidden.
+
+---
+
+## 5. Component changes
+
+### 5.1 New
+
+- `src/payments/auth-mode.ts` — resolver, header builder, key file I/O (`0600`).
+- `src/commands/login.ts` — `franklin login <key>` / `franklin login --show` /
+  `franklin logout`. Validates the key with one cheap live call before persisting;
+  refuses to write a key that does not authenticate.
+
+### 5.2 Modified
+
+| File | Change |
+| --- | --- |
+| `src/config.ts` | export `KEY_API_URL`, `API_KEY_FILE`; keep `API_URLS` unchanged |
+| `src/agent/llm.ts` | key headers on the streaming path; 401 fallback; estimated-cost recording |
+| `src/payments/post-with-payment.ts` | same, for every non-streaming gateway caller |
+| 16 files doing the x402 handshake | `API_URLS[chain]` → `resolvePayMode().apiBase`, merge auth headers, local pricing when unsettled |
+| `src/gateway-models.ts` | hand-review the `/api`-stripping regex |
+| `src/agent/secret-redact.ts` | add `/\bbrk_(live|test)_[A-Za-z0-9]{20,}\b/g` |
+| `src/commands/setup.ts` | offer the key path first, wallet second; Solana before Base |
+| `src/commands/balance.ts` | in key mode print key status + dashboard link (§5.5) |
+| `src/commands/doctor.ts` | report active pay mode, key validity, resolved gateway host |
+| `src/proxy/server.ts` | forward in key mode so the Anthropic-compatible proxy works |
+| `apps/desktop` panel | API-key field in settings |
+
+### 5.3 Backward compatibility — the guarantee for wallet users
+
+No key set anywhere ⇒ `resolvePayMode()` returns wallet mode ⇒ `apiBase` is exactly
+`API_URLS[loadChain()]` and `gatewayHeaders()` returns `{}`. Every wallet code path is
+untouched. This is asserted by test, not by inspection (§6).
+
+Both can coexist on one machine: keeping a key set and running `franklin --wallet`
+forces wallet mode for that invocation.
+
+### 5.4 Solana before Base
+
+Code default already is Solana. Remaining work is ordering and copy: setup wizard
+prompt order, README examples, `docs/`, the desktop chain picker, and any
+`base … or solana` phrasing. The Base-wallet no-strand heuristic in `loadChain()`
+**stays** — flipping it would move existing users' spend to an empty Solana wallet.
+
+### 5.5 `franklin balance` in key mode
+
+Until a credit endpoint exists, print the key's masked identity, that it authenticates,
+the session's estimated spend from the local ledger, and a link to
+`user.blockrun.ai/dashboard` for the authoritative balance. Do not invent a number.
+
+---
+
+## 6. Verification plan
+
+Local (`npm test`, no network):
+
+- wallet mode with no key resolves to today's exact host and empty headers — per chain
+- key mode resolves to `https://api.blockrun.ai` and drops `/api`
+- env var beats key file; `--wallet` beats both
+- `brk_live_…` is redacted by `redactSecrets()`
+- unsettled paid calls record a non-zero estimated cost tagged `estimated`
+
+Live, against the real key (`npm run test:e2e` gated on `BLOCKRUN_API_KEY`):
+
+- one call per endpoint family: chat, exa, search, image, pm, rpc, surf
+- 401 fallback: bad key + funded wallet completes via the wallet path
+- unsupported endpoint falls back for that call only
+
+Dashboard reconciliation — **this is the answer to "钱数对不对" and must be done by
+hand**, because there is no usage API to automate it against:
+
+1. Note the dashboard credit balance and the last activity row.
+2. Run a scripted burst of exactly N calls of known types.
+3. Compare Franklin's `franklin stats` total against the dashboard's delta.
+4. Record the drift. Allow for `x-settlement-async: true` — re-check after a few
+   minutes before calling a discrepancy real.
+5. Confirm each call appears as an activity row with the right endpoint and model.
+
+Expected outcome: an exact match on flat-rate endpoints, and a small drift on
+token-metered chat where `estimateCost()` diverges from the gateway's real rate. If the
+drift is material, §7 becomes a hard blocker rather than a nice-to-have.
+
+---
+
+## 7. Gateway-side asks (not this repo)
+
+1. **A charge header on API-key responses**, e.g.
+   `x-blockrun-charged-usd: 0.002000`. This removes all estimation and makes
+   Franklin's ledger exact in both modes. Franklin should read it opportunistically
+   from day one so it starts working the moment it ships.
+2. **A key-scoped credit endpoint**, e.g. `GET /v1/credits` →
+   `{ balance_usd, spent_today_usd }`, so `franklin balance` and low-balance warnings
+   work in key mode.
+3. Clarify `"payer":"pilot"` — whether that reflects a pilot tier on this specific key
+   or is constant, since it may affect pricing users are quoted.
+
+---
+
+## 8. README rewrite
+
+- Delete "No subscriptions. No API keys. No account." → keep "No subscriptions", and
+  state the two on-ramps.
+- New **"Two ways to pay"** section right after the pitch:
+  - **Wallet (crypto-native).** No signup. `franklin setup solana`, send USDC, done.
+  - **API key (prepaid credit).** Sign up at `user.blockrun.ai`, top up, create a key,
+    `franklin login brk_live_…`.
+- Quick start gains a step 3b for the key path; every chain example puts Solana first.
+- New **"Sign up and top up"** section: the `user.blockrun.ai` link, where the key
+  lives in the dashboard, how to add credit, where to watch activity and spend.
+- Free tier section: state that free models need neither a wallet nor a key.
+- Keep the wallet as the headline narrative — "wallet is identity" stays, with the key
+  presented as the on-ramp for people who are not there yet.
+
+---
+
+## 9. Out of scope
+
+- Removing the four dead `/v1/…` paths (separate cleanup).
+- Any change to the x402 protocol handling itself.
+- Team/multi-key management.
+- Auto top-up from a wallet into credit.

--- a/docs/plans/2026-09-05-api-key-auth-design.md
+++ b/docs/plans/2026-09-05-api-key-auth-design.md
@@ -1,7 +1,7 @@
 # API-key auth alongside the wallet — design
 
 **Date:** 2026-09-05
-**Status:** proposed
+**Status:** implemented on `feat/api-key-auth` (2026-09-05)
 **Scope:** `@blockrun/franklin` (this repo) + README. Gateway-side asks are listed but out of repo scope.
 
 ---
@@ -238,7 +238,8 @@ They operate on an estimate, and that is stated plainly rather than hidden.
 | `src/commands/balance.ts` | in key mode print key status + dashboard link (§5.5) |
 | `src/commands/doctor.ts` | report active pay mode, key validity, resolved gateway host |
 | `src/proxy/server.ts` | forward in key mode so the Anthropic-compatible proxy works |
-| `apps/desktop` panel | API-key field in settings |
+| `src/proxy/server.ts` | `applyGatewayAuth` on the forwarded header bag |
+| `apps/desktop` panel | wallet page states when spend comes from a key (see §9) |
 
 ### 5.3 Backward compatibility — the guarantee for wallet users
 
@@ -280,7 +281,7 @@ Live, against the real key (`npm run test:e2e` gated on `BLOCKRUN_API_KEY`):
 - 401 fallback: bad key + funded wallet completes via the wallet path
 - unsupported endpoint falls back for that call only
 
-Dashboard reconciliation — **this is the answer to "钱数对不对" and must be done by
+Dashboard reconciliation — **this is how we answer "are the amounts right" and must be done by
 hand**, because there is no usage API to automate it against:
 
 1. Note the dashboard credit balance and the last activity row.
@@ -290,9 +291,19 @@ hand**, because there is no usage API to automate it against:
    minutes before calling a discrepancy real.
 5. Confirm each call appears as an activity row with the right endpoint and model.
 
-Expected outcome: an exact match on flat-rate endpoints, and a small drift on
-token-metered chat where `estimateCost()` diverges from the gateway's real rate. If the
-drift is material, §7 becomes a hard blocker rather than a nice-to-have.
+Expected outcome: **Franklin's tally reads high**, by a known and predictable amount.
+user.blockrun.ai states that key mode bills provider list price with no markup and no
+per-call fee (the only charge is 5.5% + $0.30 at top-up), whereas the x402 rate card
+Franklin prices from carries a 5% margin plus a $0.001 per-transaction fee
+(`GATEWAY_MARGIN` / `GATEWAY_TRANSACTION_FEE_USD` in `src/gateway-models.ts`). So the
+estimate over-counts by roughly 5% plus $0.001 per call.
+
+That direction is deliberate — over-counting is the safe side of a spend ceiling — and it
+is disclosed rather than hidden. It is not worth "correcting" by guessing at a key-mode
+formula we have only seen stated in marketing copy; §7's charge header removes the
+guesswork entirely and should be the fix. Reconciliation should confirm the drift is
+about that size and no larger. A drift in the other direction (Franklin under-counting)
+would be a real bug and a blocker.
 
 ---
 
@@ -327,9 +338,44 @@ drift is material, §7 becomes a hard blocker rather than a nice-to-have.
 
 ---
 
-## 9. Out of scope
+## 9. What shipped, and what did not
+
+Built and verified against the live gateway:
+
+- `resolvePayMode()` / `gatewayHeaders()` / `applyGatewayAuth()` and the host swap
+  across all 43 gateway callers, including the Anthropic-compatible payment proxy.
+- `franklin login` / `logout`, the `--wallet` override, key-aware `balance`, `doctor`
+  and `setup`, and `brk_` redaction.
+- The price catalog, so key-mode calls record a real amount instead of $0.
+- 23 unit tests plus live runs of chat, Exa, Surf and the proxy in both modes.
+
+**One bug was found and fixed during live testing.** The proxy forwards the client's
+headers with Node's lowercased names, and `gatewayHeaders()` returns the canonical
+`Authorization`. A plain object holds both, `fetch` sent two Authorization headers, the
+gateway read the client's and answered 401. `applyGatewayAuth` now strips every case
+variant first; covered by a regression test.
+
+**Not done — deliberately deferred:**
+
+- **An editable API-key field in the desktop panel.** The desktop talks to the CLI over
+  a websocket RPC that is read-only for credentials by design — the CLI owns everything
+  in `~/.blockrun/` and never exports a key. Adding a write path for secrets is a
+  larger security decision than this change should make on its own. What did ship is
+  the honest half: `wallet.info` now reports `payMode`, and the wallet page says spend
+  is coming from a key rather than presenting the USDC balance as the budget. Keys are
+  set from the terminal with `franklin login`.
+
+## 10. Out of scope
 
 - Removing the four dead `/v1/…` paths (separate cleanup).
 - Any change to the x402 protocol handling itself.
 - Team/multi-key management.
 - Auto top-up from a wallet into credit.
+
+## 11. Unrelated defect noticed while testing
+
+`SurfMarket` fails on the Solana wallet path with
+`{"error":"Payment verification failed","reason":"verification_failed"}` — the signature
+is produced and sent, and the gateway rejects it. **This reproduces identically on
+`main`**, so it predates this change and is not a regression from it. It needs its own
+investigation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockrun/franklin",
-  "version": "3.43.1",
+  "version": "3.44.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockrun/franklin",
-      "version": "3.43.1",
+      "version": "3.44.0",
       "license": "Apache-2.0",
       "workspaces": [
         "apps/desktop"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockrun/franklin",
-  "version": "3.43.1",
+  "version": "3.44.0",
   "description": "Franklin Agent — The AI agent with a wallet. Spends USDC autonomously to get real work done. Pay per action, no subscriptions.",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@blockrun/franklin",
   "version": "3.43.1",
-  "description": "Franklin Agent \u2014 The AI agent with a wallet. Spends USDC autonomously to get real work done. Pay per action, no subscriptions.",
+  "description": "Franklin Agent — The AI agent with a wallet. Spends USDC autonomously to get real work done. Pay per action, no subscriptions.",
   "type": "module",
   "exports": {
     ".": {
@@ -38,7 +38,7 @@
     "desktop:package:win": "npm run dist:win --workspace @blockrun/franklin-desktop",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
-    "test": "npm run build && node --test --test-concurrency=4 --test-reporter=spec test/local.mjs test/serve-security.local.mjs test/skills.local.mjs test/repair.mjs test/model-resolver.mjs test/exa.local.mjs test/audit-batch.local.mjs test/polymarket.local.mjs test/market.local.mjs test/hooks.local.mjs test/scheduler.local.mjs test/trade-plan.local.mjs test/goal.local.mjs test/memory.local.mjs test/agent-host.local.mjs test/reservation.local.mjs",
+    "test": "npm run build && node --test --test-concurrency=4 --test-reporter=spec test/local.mjs test/api-key.local.mjs test/serve-security.local.mjs test/skills.local.mjs test/repair.mjs test/model-resolver.mjs test/exa.local.mjs test/audit-batch.local.mjs test/polymarket.local.mjs test/market.local.mjs test/hooks.local.mjs test/scheduler.local.mjs test/trade-plan.local.mjs test/goal.local.mjs test/memory.local.mjs test/agent-host.local.mjs test/reservation.local.mjs",
     "test:e2e": "npm run build && node --test --test-reporter=spec test/e2e.mjs",
     "e2e:polymarket:readonly": "npm run build && node scripts/polymarket-e2e-readonly.mjs",
     "test:free-models": "npm run build && node --test --test-reporter=spec test/free-model-matrix.mjs",

--- a/src/agent/intent-prefetch.ts
+++ b/src/agent/intent-prefetch.ts
@@ -213,13 +213,14 @@ async function exaAnswerTry(query: string, client: ModelClient): Promise<{ text:
     // We inline the request rather than invoke the capability through the full
     // tool framework because prefetch runs outside the agent loop — no
     // permission prompt, no streaming.
-    const { loadChain, API_URLS } = await import('../config.js');
+    const { loadChain } = await import('../config.js');
+    const { gatewayBase, gatewayHeaders } = await import('../payments/auth-mode.js');
     const chain = loadChain();
-    const apiUrl = API_URLS[chain];
+    const apiUrl = gatewayBase();
     void client; // (future: unify the paid-endpoint client so we reuse wallet caching)
     const res = await fetch(`${apiUrl}/v1/exa/answer`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...gatewayHeaders() },
       body: JSON.stringify({ query }),
     });
     if (res.status === 402) {

--- a/src/agent/llm.ts
+++ b/src/agent/llm.ts
@@ -15,6 +15,7 @@ import {
   SOLANA_NETWORK,
 } from '@blockrun/llm';
 import { USER_AGENT, type Chain } from '../config.js';
+import { gatewayHeaders } from '../payments/auth-mode.js';
 import { appendSettlementRow, type SettlementMeta } from '../stats/cost-log.js';
 import { routeRequest, parseRoutingProfile } from '../router/index.js';
 import type {
@@ -774,8 +775,12 @@ export class ModelClient {
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
       'anthropic-version': '2023-06-01',
+      // Placeholder for Anthropic-shaped clients — the real credential is
+      // either the x402 signature added on the 402 retry, or the bearer key
+      // that gatewayHeaders() contributes in API-key mode.
       'x-api-key': 'x402-agent-handles-auth',
       'User-Agent': USER_AGENT,
+      ...gatewayHeaders(),
     };
 
     // Enable prompt caching + extended thinking betas for Anthropic models

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -2253,9 +2253,12 @@ export async function interactiveSession(
       // promo pricing, prompt-cache discounts, or per-call flat fees
       // (verified 2026-05-09 against cost_log.jsonl: token-based
       // estimate said $34.79 across the same calls the wallet only
-      // paid $2.24 for — a 15× drift). estimateCost only fills in
-      // when no payment was made (free model / cached / pre-stream
-      // failure), where the gateway charge is genuinely 0.
+      // paid $2.24 for — a 15× drift). estimateCost fills in when no x402
+      // payment was made: a free model / cached / pre-stream failure, where
+      // the gateway charge is genuinely 0 — and every call in API-key mode,
+      // where the gateway settles against the prepaid balance and returns no
+      // charge amount at all. The estimate is flagged as such so `franklin
+      // stats` does not present it as a settled figure.
       //
       // Pass the fallback flag so franklin-stats.json's totalFallbacks +
       // per-model fallbackCount stay in sync with the audit log a few
@@ -2266,7 +2269,11 @@ export async function interactiveSession(
         ? paidUsd
         : estimateCost(resolvedModel, inputTokens, usage.outputTokens, 1);
       const llmLatencyMs = Date.now() - llmCallStartedAt;
-      recordUsage(resolvedModel, inputTokens, usage.outputTokens, callCost, llmLatencyMs, turnFailedModels.size > 0);
+      recordUsage(
+        resolvedModel, inputTokens, usage.outputTokens, callCost, llmLatencyMs,
+        turnFailedModels.size > 0,
+        paidUsd <= 0,
+      );
 
       // ── Circuit breakers: prevent infinite-loop wallet drain ──
       // Per-turn $-cap was removed in v3.11.0 — runaway loops are caught by

--- a/src/agent/secret-redact.ts
+++ b/src/agent/secret-redact.ts
@@ -124,6 +124,18 @@ const SECRET_PATTERNS: SecretPattern[] = [
   },
 
   // ── Stripe ──
+  // ── BlockRun ──
+  // Prepaid API keys for the api.blockrun.ai gateway. Franklin reads these
+  // from BLOCKRUN_API_KEY / ~/.blockrun/api-key, so without this pattern a
+  // key can reach transcripts, `franklin logs`, and any model prompt that
+  // echoes the environment.
+  {
+    label: 'blockrun_api_key',
+    pattern: /\bbrk_(?:live|test)_[A-Za-z0-9]{20,}\b/g,
+    description: 'BlockRun gateway API key',
+    envVar: 'BLOCKRUN_API_KEY',
+  },
+
   {
     label: 'stripe_live',
     pattern: /\bsk_live_[A-Za-z0-9]{20,}\b/g,

--- a/src/commands/balance.ts
+++ b/src/commands/balance.ts
@@ -1,9 +1,39 @@
 import chalk from 'chalk';
 import { setupAgentWallet, setupAgentSolanaWallet } from '@blockrun/llm';
-import { loadChain } from '../config.js';
+import { loadChain, DASHBOARD_URL } from '../config.js';
+import { isKeyMode, loadApiKey, maskApiKey } from '../payments/auth-mode.js';
+import { loadStats } from '../stats/tracker.js';
 
 export async function balanceCommand() {
   const chain = loadChain();
+
+  // API-key mode settles against a prepaid credit balance. The gateway exposes
+  // no key-scoped balance or usage endpoint, so there is no number to print
+  // that would be true — report what is known (the key works, what Franklin
+  // has spent locally) and send the user to the authority for the rest, rather
+  // than inventing a figure.
+  if (isKeyMode()) {
+    const key = loadApiKey();
+    console.log(`Pay mode:  ${chalk.green('api-key')}`);
+    console.log(`Key:       ${chalk.cyan(key ? maskApiKey(key) : 'unknown')}`);
+    try {
+      const stats = loadStats();
+      const spent = stats.totalCostUsd ?? 0;
+      const est = stats.totalEstimatedCostUsd ?? 0;
+      console.log(
+        `Spent:     ${chalk.yellow((est > 0 ? '~$' : '$') + spent.toFixed(4))}` +
+        chalk.dim('  (Franklin\'s local tally, all time)')
+      );
+    } catch { /* stats are best-effort */ }
+    console.log(
+      chalk.dim(`\nCredit balance and full activity: ${DASHBOARD_URL}/dashboard`)
+    );
+    console.log(
+      chalk.dim('Franklin cannot read the credit balance — the gateway exposes no endpoint for it.')
+    );
+    console.log(chalk.dim('To spend from a USDC wallet instead: franklin --wallet, or franklin logout.'));
+    return;
+  }
 
   try {
     if (chain === 'solana') {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -19,7 +19,8 @@ import {
   setupAgentWallet,
   setupAgentSolanaWallet,
 } from '@blockrun/llm';
-import { loadChain, API_URLS, VERSION, BLOCKRUN_DIR } from '../config.js';
+import { loadChain, VERSION, BLOCKRUN_DIR, DASHBOARD_URL, KEY_API_URL, USER_AGENT } from '../config.js';
+import { gatewayBase, isKeyMode, loadApiKey, maskApiKey } from '../payments/auth-mode.js';
 import { isTelemetryEnabled, readAllRecords, telemetryPaths } from '../telemetry/store.js';
 import { getAvailableUpdateFresh, kickoffVersionCheck } from '../version-check.js';
 
@@ -28,6 +29,23 @@ interface Check {
   status: 'ok' | 'warn' | 'fail';
   detail: string;
   remedy?: string;
+}
+
+/** Free, auth-gated probe — proves the key works without spending credit. */
+async function verifyKeyReachable(): Promise<{ ok: boolean; detail: string }> {
+  const key = loadApiKey();
+  if (!key) return { ok: false, detail: 'no key resolved' };
+  try {
+    const res = await fetch(`${KEY_API_URL}/v1/models`, {
+      headers: { Authorization: `Bearer ${key}`, 'User-Agent': USER_AGENT },
+      signal: AbortSignal.timeout(8_000),
+    });
+    if (res.status === 401) return { ok: false, detail: 'gateway returned 401' };
+    if (!res.ok) return { ok: false, detail: `gateway returned HTTP ${res.status}` };
+    return { ok: true, detail: 'authenticated' };
+  } catch (err) {
+    return { ok: false, detail: err instanceof Error ? err.message : 'unreachable' };
+  }
 }
 
 async function runChecks(): Promise<Check[]> {
@@ -106,6 +124,31 @@ async function runChecks(): Promise<Check[]> {
 
   // ── 5. Wallet ─────────────────────────────────────────────────────
   let walletBalance: number | null = null;
+  // ── Pay mode ──────────────────────────────────────────────────────
+  // Which credential will actually be spent matters more than any single
+  // check below — a user with a key set but an unfunded wallet is healthy,
+  // and vice versa, so name the mode before reporting on either.
+  if (isKeyMode()) {
+    const key = loadApiKey();
+    const verdict = await verifyKeyReachable();
+    out.push({
+      name: 'Pay mode',
+      status: verdict.ok ? 'ok' : 'fail',
+      detail: verdict.ok
+        ? `api-key ${key ? maskApiKey(key) : ''} → ${gatewayBase()}`
+        : `api-key rejected — ${verdict.detail}`,
+      remedy: verdict.ok
+        ? undefined
+        : `Check the key at ${DASHBOARD_URL}/dashboard, or run \`franklin logout\` to fall back to the wallet`,
+    });
+  } else {
+    out.push({
+      name: 'Pay mode',
+      status: 'ok',
+      detail: `wallet (${chain ?? 'unset'}) → ${gatewayBase()}`,
+    });
+  }
+
   let walletAddress = '';
   if (chain) {
     try {
@@ -164,7 +207,7 @@ async function runChecks(): Promise<Check[]> {
 
   // ── 6. Gateway reachability ───────────────────────────────────────
   if (chain) {
-    const apiUrl = API_URLS[chain];
+    const apiUrl = gatewayBase();
     try {
       const ctl = new AbortController();
       const t = setTimeout(() => ctl.abort(), 5000);

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,0 +1,112 @@
+/**
+ * `franklin login` — hand Franklin a prepaid BlockRun API key.
+ *
+ * The wallet remains Franklin's identity; a key is the second on-ramp for
+ * people who would rather top up a balance at user.blockrun.ai than fund a
+ * USDC wallet. Both can be configured at once — the key wins, and `--wallet`
+ * on any run forces the wallet back for that invocation.
+ *
+ * The key is verified against the gateway before it is written, so a
+ * truncated paste or a revoked key fails here rather than as a confusing 401
+ * partway through a session.
+ */
+
+import chalk from 'chalk';
+import { KEY_API_URL, API_KEY_FILE, DASHBOARD_URL, USER_AGENT, loadChain } from '../config.js';
+import {
+  clearApiKey,
+  isApiKeyShaped,
+  loadApiKey,
+  maskApiKey,
+  saveApiKey,
+} from '../payments/auth-mode.js';
+
+/**
+ * GET /v1/models is free and auth-gated on the key host — 401 without a valid
+ * key, 200 with one. That makes it the right probe: it proves the key works
+ * without spending any of the balance it is checking.
+ */
+async function verifyKey(key: string): Promise<{ ok: boolean; detail: string }> {
+  try {
+    const res = await fetch(`${KEY_API_URL}/v1/models`, {
+      headers: { Authorization: `Bearer ${key}`, 'User-Agent': USER_AGENT },
+      signal: AbortSignal.timeout(20_000),
+    });
+    if (res.status === 401) return { ok: false, detail: 'gateway rejected the key (401)' };
+    if (!res.ok) return { ok: false, detail: `gateway returned HTTP ${res.status}` };
+    const body = (await res.json()) as { data?: unknown[] };
+    const count = Array.isArray(body.data) ? body.data.length : 0;
+    return { ok: true, detail: `${count} models available` };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'unknown error';
+    return { ok: false, detail: `could not reach ${KEY_API_URL} — ${msg}` };
+  }
+}
+
+function printStatus(): void {
+  const key = loadApiKey();
+  const fromEnv = Boolean(process.env.BLOCKRUN_API_KEY?.trim());
+
+  if (!key) {
+    console.log(`Pay mode: ${chalk.magenta('wallet')} (${chalk.magenta(loadChain())})`);
+    console.log(chalk.dim('\nNo API key configured. Franklin pays with the USDC wallet.'));
+    console.log(chalk.dim(`Want a prepaid key instead? Sign up at ${DASHBOARD_URL}, then:`));
+    console.log(chalk.dim('  franklin login brk_live_...'));
+    return;
+  }
+
+  console.log(`Pay mode: ${chalk.green('api-key')}`);
+  console.log(`Key:      ${chalk.cyan(maskApiKey(key))}`);
+  console.log(`Source:   ${chalk.dim(fromEnv ? 'BLOCKRUN_API_KEY (env)' : API_KEY_FILE)}`);
+  console.log(`Gateway:  ${chalk.dim(KEY_API_URL)}`);
+  console.log(chalk.dim(`\nBalance and activity: ${DASHBOARD_URL}/dashboard`));
+  console.log(chalk.dim('Force the wallet for one run with `franklin --wallet`.'));
+}
+
+export async function loginCommand(key?: string): Promise<void> {
+  if (!key) {
+    printStatus();
+    return;
+  }
+
+  const trimmed = key.trim();
+  if (!isApiKeyShaped(trimmed)) {
+    console.log(chalk.red('That does not look like a BlockRun API key.'));
+    console.log(chalk.dim('Expected `brk_live_...` or `brk_test_...`.'));
+    console.log(chalk.dim(`Create one at ${DASHBOARD_URL}/dashboard.`));
+    process.exit(1);
+  }
+
+  process.stdout.write(chalk.dim('Verifying key… '));
+  const { ok, detail } = await verifyKey(trimmed);
+  if (!ok) {
+    console.log(chalk.red('failed'));
+    console.log(chalk.red(`  ${detail}`));
+    console.log(chalk.dim(`\nNothing was saved. Check the key at ${DASHBOARD_URL}/dashboard.`));
+    process.exit(1);
+  }
+  console.log(chalk.green('ok') + chalk.dim(` — ${detail}`));
+
+  saveApiKey(trimmed);
+  console.log(`\nSaved ${chalk.cyan(maskApiKey(trimmed))} to ${chalk.dim(API_KEY_FILE)}`);
+  console.log(chalk.dim('Franklin now pays from your prepaid balance instead of the wallet.'));
+  console.log(chalk.dim(`Top up and watch spend at ${DASHBOARD_URL}/dashboard.`));
+  console.log(chalk.dim('Your wallet is untouched — `franklin --wallet` still spends from it.'));
+}
+
+export async function logoutCommand(): Promise<void> {
+  const removed = clearApiKey();
+  if (!removed) {
+    console.log(chalk.dim('No stored API key to remove.'));
+  } else {
+    console.log(`Removed ${chalk.dim(API_KEY_FILE)}.`);
+  }
+
+  if (process.env.BLOCKRUN_API_KEY?.trim()) {
+    console.log(
+      chalk.yellow('BLOCKRUN_API_KEY is still set in your environment — unset it to fall back to the wallet.')
+    );
+    return;
+  }
+  console.log(`Pay mode is now ${chalk.magenta('wallet')} (${chalk.magenta(loadChain())}).`);
+}

--- a/src/commands/models.ts
+++ b/src/commands/models.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
-import { loadChain, API_URLS } from '../config.js';
+import { loadChain} from '../config.js';
+import { gatewayBase } from '../payments/auth-mode.js';
 import {
   getGatewayModels,
   GATEWAY_MARGIN,
@@ -119,7 +120,7 @@ function printSection(heading: string, models: GatewayModel[], render: (m: Gatew
 
 export async function modelsCommand() {
   const chain = loadChain();
-  const apiUrl = API_URLS[chain];
+  const apiUrl = gatewayBase();
 
   console.log(chalk.bold('Available Models\n'));
   console.log(`Chain: ${chalk.magenta(chain)} — ${chalk.dim(apiUrl)}\n`);

--- a/src/commands/plugin.ts
+++ b/src/commands/plugin.ts
@@ -8,7 +8,8 @@
 import chalk from 'chalk';
 import readline from 'node:readline';
 import { ModelClient } from '../agent/llm.js';
-import { loadChain, API_URLS } from '../config.js';
+import { loadChain} from '../config.js';
+import { gatewayBase } from '../payments/auth-mode.js';
 import { loadAllPlugins, getPlugin, listWorkflowPlugins } from '../plugins/registry.js';
 import {
   loadWorkflowConfig,
@@ -52,7 +53,7 @@ export async function pluginCommand(
 
   const workflow = workflowFactory();
   const chain = loadChain();
-  const apiUrl = API_URLS[chain];
+  const apiUrl = gatewayBase();
   const client = new ModelClient({ apiUrl, chain, debug: options.debug });
 
   const existingConfig = loadWorkflowConfig(workflow.id);

--- a/src/commands/predict.ts
+++ b/src/commands/predict.ts
@@ -17,7 +17,8 @@
 import { interactiveSession } from '../agent/loop.js';
 import type { AgentConfig, StreamEvent, StreamTurnDone } from '../agent/types.js';
 import { predictionCapabilities, resetToolSessionState } from '../tools/index.js';
-import { loadChain, API_URLS } from '../config.js';
+import { loadChain} from '../config.js';
+import { gatewayBase } from '../payments/auth-mode.js';
 import { resolveModel } from '../ui/model-picker.js';
 
 export interface PredictOptions {
@@ -68,7 +69,7 @@ export async function predictCommand(options: PredictOptions): Promise<void> {
   }
 
   const chain = loadChain();
-  const apiUrl = API_URLS[chain];
+  const apiUrl = gatewayBase();
   const model = resolveModel(options.model);
   const asJson = options.json !== false;
 

--- a/src/commands/proxy.ts
+++ b/src/commands/proxy.ts
@@ -6,7 +6,8 @@
 import chalk from 'chalk';
 import { getOrCreateWallet, getOrCreateSolanaWallet } from '@blockrun/llm';
 import { createProxy } from '../proxy/server.js';
-import { loadChain, API_URLS, DEFAULT_PROXY_PORT } from '../config.js';
+import { loadChain, DEFAULT_PROXY_PORT} from '../config.js';
+import { gatewayBase } from '../payments/auth-mode.js';
 import { loadConfig } from './config.js';
 import { printBanner } from '../banner.js';
 
@@ -21,7 +22,7 @@ interface ProxyOptions {
 export async function proxyCommand(options: ProxyOptions) {
   const version = options.version ?? '1.0.0';
   const chain = loadChain();
-  const apiUrl = API_URLS[chain];
+  const apiUrl = gatewayBase();
   const fallbackEnabled = options.fallback !== false;
   const config = loadConfig();
 

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -5,12 +5,25 @@ import {
   getOrCreateSolanaWallet,
   scanSolanaWallets,
 } from '@blockrun/llm';
-import { type Chain, saveChain } from '../config.js';
+import { type Chain, saveChain, DASHBOARD_URL } from '../config.js';
+import { isKeyMode, loadApiKey, maskApiKey } from '../payments/auth-mode.js';
 
 export async function setupCommand(chainArg?: string) {
   // Solana is the default chain; `franklin setup base` opts into Base.
   const chain: Chain =
     chainArg === 'base' ? 'base' : 'solana';
+
+  // A configured key already pays for everything, so creating a wallet here
+  // would be busywork the user did not ask for. Say so and stop, rather than
+  // silently making a second credential they will never fund.
+  if (isKeyMode()) {
+    const key = loadApiKey();
+    console.log(chalk.green('Already set up with an API key.'));
+    console.log(`Key: ${chalk.cyan(key ? maskApiKey(key) : 'unknown')}`);
+    console.log(chalk.dim(`\nTop up at ${DASHBOARD_URL}/dashboard, then run \`franklin start\`.`));
+    console.log(chalk.dim('Want a USDC wallet as well? Run `franklin logout` first, then `franklin setup`.'));
+    return;
+  }
 
   if (chain === 'solana') {
     const wallets = scanSolanaWallets();
@@ -65,4 +78,8 @@ export async function setupCommand(chainArg?: string) {
     `Then run ${chalk.bold('franklin start')} to begin.\n`
   );
   console.log(chalk.dim(`Chain: ${chain} — saved to ~/.blockrun/`));
+  console.log(
+    chalk.dim(`\nPrefer a prepaid balance to a wallet? Sign up at ${DASHBOARD_URL},`)
+  );
+  console.log(chalk.dim('then run `franklin login brk_live_...` — no crypto required.'));
 }

--- a/src/commands/slack.ts
+++ b/src/commands/slack.ts
@@ -9,7 +9,8 @@
  */
 
 import chalk from 'chalk';
-import { loadChain, API_URLS } from '../config.js';
+import { loadChain} from '../config.js';
+import { gatewayBase } from '../payments/auth-mode.js';
 import { assembleInstructions } from '../agent/context.js';
 import { allCapabilities } from '../tools/index.js';
 import { loadMcpConfig } from '../mcp/config.js';
@@ -53,7 +54,7 @@ export async function slackCommand(opts: SlackCommandOptions): Promise<void> {
   }
 
   const chain = loadChain();
-  const apiUrl = API_URLS[chain];
+  const apiUrl = gatewayBase();
   const config = loadConfig();
 
   const model =

--- a/src/commands/social.ts
+++ b/src/commands/social.ts
@@ -28,7 +28,8 @@ import {
 import { SocialBrowser, SOCIAL_PROFILE_DIR } from '../social/browser.js';
 import { runX, type RunResult } from '../social/x.js';
 import { getStats } from '../social/db.js';
-import { loadChain, API_URLS } from '../config.js';
+import { loadChain} from '../config.js';
+import { gatewayBase } from '../payments/auth-mode.js';
 import { loadConfig as loadAppConfig } from './config.js';
 import { FREE_DEFAULT_MODEL } from '../free-models.js';
 
@@ -194,7 +195,7 @@ async function runCommand(options: SocialCommandOptions): Promise<void> {
   console.log('');
 
   const chain = loadChain();
-  const apiUrl = API_URLS[chain];
+  const apiUrl = gatewayBase();
   const appConfig = loadAppConfig();
   const model =
     options.model || appConfig['default-model'] || FREE_DEFAULT_MODEL;

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -2,7 +2,8 @@ import chalk from 'chalk';
 import fs from 'node:fs';
 import path from 'node:path';
 import { getOrCreateWallet, getOrCreateSolanaWallet } from '@blockrun/llm';
-import { BLOCKRUN_DIR, loadChain, API_URLS } from '../config.js';
+import { BLOCKRUN_DIR, loadChain} from '../config.js';
+import { gatewayBase } from '../payments/auth-mode.js';
 import { retryFetchBalance } from './balance-retry.js';
 import { flushStats, loadStats, getLiveSpendUsd } from '../stats/tracker.js';
 import { OPUS_PRICING } from '../pricing.js';
@@ -96,7 +97,7 @@ export async function startCommand(options: StartOptions) {
       chain = sessMeta.chain;
     }
   }
-  const apiUrl = API_URLS[chain];
+  const apiUrl = gatewayBase();
   const config = loadConfig();
 
   // Resolve model. Priority: explicit --model > resumed session's model > user

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -4,6 +4,8 @@
  */
 
 import chalk from 'chalk';
+import { DASHBOARD_URL } from '../config.js';
+import { isKeyMode } from '../payments/auth-mode.js';
 import { loadStats, clearStats, getStatsSummary } from '../stats/tracker.js';
 import { summarizeSdkSettlements } from '../stats/cost-log.js';
 
@@ -105,10 +107,21 @@ export function statsCommand(options: StatsOptions): void {
   console.log(
     `    Requests:       ${chalk.cyan(stats.totalRequests.toLocaleString())}`
   );
+  // In API-key mode the gateway settles against a prepaid balance and returns
+  // no per-call charge, so spend is priced locally from the published catalog.
+  // Mark that plainly rather than presenting an estimate as a settled figure.
+  const estimatedUsd = stats.totalEstimatedCostUsd ?? 0;
+  const mostlyEstimated = estimatedUsd > 0 && estimatedUsd >= stats.totalCostUsd * 0.5;
   console.log(
-    `    Recorded Cost:  ${chalk.green('$' + stats.totalCostUsd.toFixed(4))}` +
+    `    Recorded Cost:  ${chalk.green((mostlyEstimated ? '~$' : '$') + stats.totalCostUsd.toFixed(4))}` +
       chalk.gray('  (franklin-stats.json — main loop + proxy + tools that call recordUsage)')
   );
+  if (estimatedUsd > 0) {
+    console.log(
+      `    of which est.:  ${chalk.yellow('$' + estimatedUsd.toFixed(4))}` +
+        chalk.gray('  (priced from the published catalog, not a settled x402 amount)')
+    );
+  }
   if (sdkTotal > 0) {
     const ledgerColor = significantGap ? chalk.yellow : chalk.green;
     console.log(
@@ -239,6 +252,14 @@ export function statsCommand(options: StatsOptions): void {
   }
 
   console.log('\n' + '─'.repeat(55));
+  if (isKeyMode()) {
+    // The key gateway reports no per-call charge, so nothing Franklin prints
+    // here can be authoritative. Say where the real number lives.
+    console.log(
+      chalk.gray(`  Paying by API key — the authoritative balance and activity log live at\n`) +
+      chalk.gray(`  ${DASHBOARD_URL}/dashboard\n`)
+    );
+  }
   console.log(
     chalk.gray('  Run `franklin stats --clear` to reset statistics\n')
   );

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -9,7 +9,8 @@
  */
 
 import chalk from 'chalk';
-import { loadChain, API_URLS } from '../config.js';
+import { loadChain} from '../config.js';
+import { gatewayBase } from '../payments/auth-mode.js';
 import { assembleInstructions } from '../agent/context.js';
 import { allCapabilities } from '../tools/index.js';
 import { loadConfig } from './config.js';
@@ -53,7 +54,7 @@ export async function telegramCommand(opts: TelegramCommandOptions): Promise<voi
   }
 
   const chain = loadChain();
-  const apiUrl = API_URLS[chain];
+  const apiUrl = gatewayBase();
   const config = loadConfig();
 
   // Model: --model flag > config default > free default.

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,3 +60,23 @@ export function loadChain(): Chain {
   const hasSolanaWallet = fs.existsSync(path.join(BLOCKRUN_DIR, '.solana-session'));
   return hasBaseWallet && !hasSolanaWallet ? 'base' : 'solana';
 }
+
+// ── API-key mode ──────────────────────────────────────────────────────────
+// BlockRun runs a second, prepaid-credit gateway that authenticates with a
+// bearer key instead of an x402 signature. It shares no auth with the x402
+// hosts above: a bearer key sent to blockrun.ai/api is ignored (still 402),
+// and this host 401s when the key is missing or bad — there is no x402
+// fallback on it. That isolation is what lets key mode ship without touching
+// wallet users.
+//
+// Note the path shape differs: API_URLS entries end in `/api`, this one does
+// not — api.blockrun.ai serves `/v1/...` at the root and returns a
+// `wrong_host` 404 for `/api/v1/...`. Callers that build `${base}/v1/...`
+// work unchanged in both modes; callers that assume the `/api` suffix do not.
+export const KEY_API_URL = 'https://api.blockrun.ai';
+
+/** Where `franklin login` persists the key (0600). */
+export const API_KEY_FILE = path.join(BLOCKRUN_DIR, 'api-key');
+
+/** Dashboard host — signup, top-up, activity. Not an API surface. */
+export const DASHBOARD_URL = 'https://user.blockrun.ai';

--- a/src/gateway-models.ts
+++ b/src/gateway-models.ts
@@ -16,7 +16,8 @@
  * is the safe direction for budget tracking).
  */
 
-import { loadChain, API_URLS, USER_AGENT, type Chain } from './config.js';
+import { loadChain, USER_AGENT, type Chain} from './config.js';
+import { gatewayBase, gatewayHeaders } from './payments/auth-mode.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────
 
@@ -146,18 +147,22 @@ export function warmGatewayModelsCache(): void {
 
 async function doFetch(): Promise<GatewayModel[]> {
   const chain = loadChain();
-  const base = API_URLS[chain].replace(/\/api$/, '');
+  // `gatewayBase()` already carries the `/api` segment on the x402 hosts and
+  // deliberately omits it on the API-key host, so append `/v1/...` to it
+  // directly rather than stripping and re-adding a prefix that only one of the
+  // two hosts has.
+  //
   // The schema/JSON gate: without ?format=json the gateway returns a
   // typed schema placeholder instead of the data envelope. Documented
   // quirk across other endpoints too.
-  const url = `${base}/api/v1/models?format=json`;
+  const url = `${gatewayBase()}/v1/models?format=json`;
 
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
   try {
     const res = await fetch(url, {
       signal: ctrl.signal,
-      headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' },
+      headers: { ...gatewayHeaders(), 'User-Agent': USER_AGENT, Accept: 'application/json' },
     });
     if (!res.ok) throw new Error(`Gateway models list returned HTTP ${res.status}`);
     const body = (await res.json()) as { data?: unknown };

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,8 +33,22 @@ import { proxyCommand } from './commands/proxy.js';
 import { buildTaskCommand } from './commands/task.js';
 import { buildContentCommand } from './commands/content.js';
 import { predictCommand } from './commands/predict.js';
+import { loginCommand, logoutCommand } from './commands/login.js';
+import { useWalletMode } from './payments/auth-mode.js';
 
 import { VERSION as version } from './config.js';
+
+// `--wallet` is process-global rather than a per-command option: it has to take
+// effect before anything resolves a pay mode, and it belongs on `balance`,
+// `doctor` and `models` too, not just `start`. Applying it straight from argv
+// is the only way to get it in ahead of commander's dispatch; it is then
+// removed so per-command parsers do not reject it as unknown. Stripping it also
+// leaves a bare `franklin --wallet` with no args, which falls through to the
+// default `start` action exactly as a bare `franklin` does.
+if (process.argv.includes('--wallet')) {
+  useWalletMode();
+  process.argv = process.argv.filter((a) => a !== '--wallet');
+}
 
 const program = new Command();
 
@@ -43,13 +57,15 @@ program
   .description(
     'Franklin Agent — The AI agent with a wallet.\n\n' +
       'While others chat, Franklin Agent spends — turning your USDC into real work.\n\n' +
-      'Pay per action in USDC on Base or Solana. No subscriptions. No accounts.'
+      'Pay per action — a USDC wallet on Solana or Base, or a prepaid API key\n' +
+      'from user.blockrun.ai. No subscriptions.'
   )
+  .option('--wallet', 'Pay from the USDC wallet even when an API key is configured')
   .version(version);
 
 program
   .command('setup [chain]')
-  .description('Create a new wallet for payments (base or solana)')
+  .description('Create a new wallet for payments (solana or base)')
   .action((chain) => setupCommand(chain));
 
 program
@@ -158,8 +174,18 @@ program
 
 program
   .command('balance')
-  .description('Check wallet USDC balance')
+  .description('Check wallet USDC balance, or API-key status in key mode')
   .action(balanceCommand);
+
+program
+  .command('login [key]')
+  .description('Store a BlockRun API key (brk_live_...) — omit the key to show current pay mode')
+  .action((key) => loginCommand(key));
+
+program
+  .command('logout')
+  .description('Remove the stored BlockRun API key and fall back to the wallet')
+  .action(logoutCommand);
 
 program
   .command('config <action> [key] [value]')

--- a/src/onramp/client.ts
+++ b/src/onramp/client.ts
@@ -16,7 +16,8 @@
  * helper.
  */
 
-import { API_URLS, loadChain } from '../config.js';
+import { loadChain } from '../config.js';
+import { gatewayBase } from '../payments/auth-mode.js';
 import { postWithPayment } from '../payments/post-with-payment.js';
 
 export interface OnrampLinkResult {
@@ -31,7 +32,7 @@ export interface OnrampLinkResult {
  */
 export async function getOnrampUrl(address: string): Promise<OnrampLinkResult> {
   const chain = loadChain();
-  const endpoint = `${API_URLS[chain]}/v1/onramp/token`;
+  const endpoint = `${gatewayBase()}/v1/onramp/token`;
   const result = await postWithPayment(
     endpoint,
     { address, network: chain, asset: 'USDC' },

--- a/src/payments/auth-mode.ts
+++ b/src/payments/auth-mode.ts
@@ -1,0 +1,224 @@
+/**
+ * Which gateway pays for this process — the x402 wallet or a prepaid API key.
+ *
+ * Franklin can reach the BlockRun gateway two ways:
+ *
+ *   wallet — blockrun.ai/api (Base) or sol.blockrun.ai/api (Solana). Every
+ *            paid call answers a 402 by signing USDC from the local wallet.
+ *   key    — api.blockrun.ai with `Authorization: Bearer brk_...`, settled
+ *            against a prepaid credit balance. No chain involved.
+ *
+ * The two hosts share no auth: a bearer key on blockrun.ai/api is ignored and
+ * still 402s, and api.blockrun.ai 401s when the key is absent or bad rather
+ * than falling back to x402. That isolation is the backward-compatibility
+ * guarantee — with no key configured this module returns exactly the host and
+ * headers Franklin used before key mode existed.
+ *
+ * Every gateway caller in src/ already funnels through `API_URLS[loadChain()]`
+ * + `/v1/...`, so swapping in `resolvePayMode().apiBase` and merging
+ * `gatewayHeaders()` is enough; the `/v1/...` concatenation is correct in both
+ * modes because the key host serves those paths at its root.
+ */
+
+import fs from 'node:fs';
+import {
+  API_URLS,
+  API_KEY_FILE,
+  BLOCKRUN_DIR,
+  KEY_API_URL,
+  USER_AGENT,
+  loadChain,
+  type Chain,
+} from '../config.js';
+
+export type PayMode =
+  | { kind: 'key'; apiBase: string; key: string }
+  | { kind: 'wallet'; apiBase: string; chain: Chain };
+
+/**
+ * Keys are `brk_live_` / `brk_test_` + an opaque alphanumeric tail. Validated
+ * on the way in so a truncated paste fails at `franklin login` rather than as
+ * a confusing 401 twenty calls later.
+ */
+export const API_KEY_PATTERN = /^brk_(?:live|test)_[A-Za-z0-9]{20,}$/;
+
+export function isApiKeyShaped(value: string): boolean {
+  return API_KEY_PATTERN.test(value.trim());
+}
+
+/** Mask for display/logs: `brk_live_H4Oz…QBW5`. Never print a whole key. */
+export function maskApiKey(key: string): string {
+  const trimmed = key.trim();
+  if (trimmed.length <= 18) return 'brk_***';
+  return `${trimmed.slice(0, 13)}…${trimmed.slice(-4)}`;
+}
+
+let cached: PayMode | null = null;
+let forceWallet = false;
+
+/**
+ * Force wallet mode for the rest of the process, regardless of any key that is
+ * set. Backs the `--wallet` flag so a user with a key on file can still spend
+ * from the wallet for one run.
+ */
+export function useWalletMode(): void {
+  forceWallet = true;
+  cached = null;
+}
+
+/**
+ * Demote to wallet mode after the gateway rejected the key (401). Called once
+ * per process — a key that does not authenticate will not authenticate on the
+ * next call either, and retrying it on every request would double the latency
+ * of an entire session.
+ */
+export function invalidateKey(): void {
+  if (cached?.kind === 'key') cached = null;
+  forceWallet = true;
+}
+
+/** Test seam — drop the memoised mode so env/file changes are re-read. */
+export function resetPayModeCache(): void {
+  cached = null;
+  forceWallet = false;
+}
+
+function readKeyFile(): string | null {
+  try {
+    const raw = fs.readFileSync(API_KEY_FILE, 'utf-8').trim();
+    return raw || null;
+  } catch {
+    return null; // no key on disk — wallet mode
+  }
+}
+
+/** The key Franklin would use, from env first then disk. Null when unset. */
+export function loadApiKey(): string | null {
+  const fromEnv = process.env.BLOCKRUN_API_KEY?.trim();
+  if (fromEnv) return fromEnv;
+  return readKeyFile();
+}
+
+export function saveApiKey(key: string): void {
+  const trimmed = key.trim();
+  fs.mkdirSync(BLOCKRUN_DIR, { recursive: true });
+  fs.writeFileSync(API_KEY_FILE, trimmed + '\n', { mode: 0o600 });
+  cached = null;
+}
+
+export function clearApiKey(): boolean {
+  try {
+    fs.unlinkSync(API_KEY_FILE);
+    cached = null;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve the active payment mode. Memoised per process — the resolution reads
+ * the filesystem and is hit on every gateway call.
+ *
+ * Precedence: `--wallet` / a rejected key > BLOCKRUN_API_KEY > ~/.blockrun/api-key
+ * > wallet on the active chain.
+ */
+export function resolvePayMode(): PayMode {
+  if (cached) return cached;
+
+  if (!forceWallet) {
+    const key = loadApiKey();
+    if (key && isApiKeyShaped(key)) {
+      cached = { kind: 'key', apiBase: KEY_API_URL, key };
+      return cached;
+    }
+  }
+
+  const chain = loadChain();
+  cached = { kind: 'wallet', apiBase: API_URLS[chain], chain };
+  return cached;
+}
+
+/** True when the next gateway call will authenticate with a key. */
+export function isKeyMode(): boolean {
+  return resolvePayMode().kind === 'key';
+}
+
+/**
+ * The gateway base URL for the active mode. Drop-in replacement for the
+ * `API_URLS[loadChain()]` that call sites used before key mode.
+ */
+export function gatewayBase(): string {
+  return resolvePayMode().apiBase;
+}
+
+/** The x402 base to retry against when a key-mode call has to fall back. */
+export function walletBase(chain: Chain = loadChain()): string {
+  return API_URLS[chain];
+}
+
+/**
+ * Auth + identity headers for the active mode. Empty of auth in wallet mode,
+ * where payment rides on the PAYMENT-SIGNATURE header instead.
+ */
+export function gatewayHeaders(mode: PayMode = resolvePayMode()): Record<string, string> {
+  const headers: Record<string, string> = { 'User-Agent': USER_AGENT };
+  if (mode.kind === 'key') headers['Authorization'] = `Bearer ${mode.key}`;
+  return headers;
+}
+
+/**
+ * Merge this mode's auth into a header bag that may already carry a client's
+ * own credential, in place.
+ *
+ * Node lowercases inbound header names while `gatewayHeaders()` returns the
+ * canonical `Authorization`, so a plain object happily holds both — and
+ * `fetch` then sends two Authorization headers. The gateway reads the client's
+ * and answers 401. Every case variant is dropped before ours goes in, so
+ * exactly one survives.
+ *
+ * Only used where Franklin forwards someone else's request (the payment
+ * proxy). Direct callers build their headers from scratch and can spread
+ * `gatewayHeaders()` instead.
+ */
+export function applyGatewayAuth(
+  headers: Record<string, string>,
+  mode: PayMode = resolvePayMode(),
+): Record<string, string> {
+  const auth = gatewayHeaders(mode);
+  if (auth.Authorization) {
+    for (const key of Object.keys(headers)) {
+      if (key.toLowerCase() === 'authorization') delete headers[key];
+    }
+  }
+  Object.assign(headers, auth);
+  return headers;
+}
+
+/**
+ * Classify a key-mode failure so callers know whether falling back to the
+ * wallet is safe.
+ *
+ * Only two statuses are worth retrying elsewhere. A 401 means the key itself
+ * is bad, so the whole process demotes. A 404 `unsupported_endpoint` means
+ * this one path is not served on the key host, so only that call falls back.
+ * Everything else — 400, 402, 5xx — surfaces as-is, so a malformed request
+ * never silently drains wallet USDC on a second attempt.
+ */
+export type KeyFailure = 'invalid-key' | 'unsupported-endpoint' | null;
+
+export function classifyKeyFailure(status: number, body: string): KeyFailure {
+  if (status === 401) return 'invalid-key';
+  if (status === 404 && body.includes('unsupported_endpoint')) return 'unsupported-endpoint';
+  return null;
+}
+
+/**
+ * Rewrite a key-host URL onto the wallet host for a fallback retry. The two
+ * differ by the `/api` segment the wallet hosts carry, so this swaps the
+ * origin and re-adds it rather than a plain string replace.
+ */
+export function toWalletUrl(url: string, chain: Chain = loadChain()): string {
+  if (!url.startsWith(KEY_API_URL)) return url;
+  return API_URLS[chain] + url.slice(KEY_API_URL.length);
+}

--- a/src/payments/post-with-payment.ts
+++ b/src/payments/post-with-payment.ts
@@ -23,6 +23,13 @@ import {
   SOLANA_NETWORK,
 } from '@blockrun/llm';
 import { loadChain, USER_AGENT, type Chain } from '../config.js';
+import {
+  classifyKeyFailure,
+  gatewayHeaders,
+  invalidateKey,
+  resolvePayMode,
+  toWalletUrl,
+} from './auth-mode.js';
 
 async function extractPaymentReq(response: Response): Promise<string | null> {
   let header = response.headers.get('payment-required');
@@ -90,6 +97,12 @@ export interface PostResult {
   status: number;
   body: Record<string, unknown>;
   raw: string;
+  /**
+   * True only when this call completed an x402 handshake, i.e. a wallet
+   * signature actually moved USDC. False in key mode and on free endpoints —
+   * callers must price those locally rather than recording zero spend.
+   */
+  settled: boolean;
 }
 
 /**
@@ -104,15 +117,45 @@ export async function postWithPayment(
   timeoutMs = 30_000,
 ): Promise<PostResult> {
   const chain = loadChain();
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-    'User-Agent': USER_AGENT,
-  };
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), timeoutMs);
 
   try {
     const payload = JSON.stringify(body);
+    const mode = resolvePayMode();
+
+    // Key mode: one authenticated POST, no 402 dance. The gateway settles
+    // against the prepaid balance and answers 200 directly.
+    if (mode.kind === 'key') {
+      const keyHeaders: Record<string, string> = {
+        'Content-Type': 'application/json',
+        ...gatewayHeaders(mode),
+      };
+      const keyResponse = await fetch(endpoint, {
+        method: 'POST',
+        signal: ctrl.signal,
+        headers: keyHeaders,
+        body: payload,
+      });
+      const keyRaw = await keyResponse.text().catch(() => '');
+      const failure = classifyKeyFailure(keyResponse.status, keyRaw);
+
+      // Only a bad key or a path the key host does not serve is worth retrying
+      // on the wallet. Anything else (400, 402, 5xx) is returned as-is so a
+      // malformed request never silently spends wallet USDC on a second try.
+      if (!failure) {
+        let parsedKey: Record<string, unknown> = {};
+        try { parsedKey = keyRaw ? JSON.parse(keyRaw) : {}; } catch { /* leave as {} */ }
+        return { ok: keyResponse.ok, status: keyResponse.status, body: parsedKey, raw: keyRaw, settled: false };
+      }
+      if (failure === 'invalid-key') invalidateKey();
+      endpoint = toWalletUrl(endpoint, chain);
+    }
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'User-Agent': USER_AGENT,
+    };
     let response = await fetch(endpoint, {
       method: 'POST',
       signal: ctrl.signal,
@@ -120,10 +163,11 @@ export async function postWithPayment(
       body: payload,
     });
 
+    let settled = false;
     if (response.status === 402) {
       const paymentHeaders = await signPayment(response, chain, endpoint, resourceDescription);
       if (!paymentHeaders) {
-        return { ok: false, status: 402, body: { error: 'payment signing failed' }, raw: '' };
+        return { ok: false, status: 402, body: { error: 'payment signing failed' }, raw: '', settled: false };
       }
       response = await fetch(endpoint, {
         method: 'POST',
@@ -131,12 +175,13 @@ export async function postWithPayment(
         headers: { ...headers, ...paymentHeaders },
         body: payload,
       });
+      settled = response.ok;
     }
 
     const raw = await response.text().catch(() => '');
     let parsed: Record<string, unknown> = {};
     try { parsed = raw ? JSON.parse(raw) : {}; } catch { /* leave as {} */ }
-    return { ok: response.ok, status: response.status, body: parsed, raw };
+    return { ok: response.ok, status: response.status, body: parsed, raw, settled };
   } finally {
     clearTimeout(timer);
   }

--- a/src/payments/price-catalog.ts
+++ b/src/payments/price-catalog.ts
@@ -1,0 +1,345 @@
+/**
+ * List prices for the gateway's flat-rate service endpoints.
+ *
+ * Wallet mode learns what a call costs from the 402 handshake — the amount is
+ * in the payment requirements, so the recorded spend is exact. API-key mode
+ * has no handshake: the gateway settles against a prepaid balance and answers
+ * 200 with no charge amount anywhere in the response. Without a price source,
+ * every paid call in key mode would record $0, which silently disables the
+ * --max-spend ceiling, the PreSpend hooks and every budget in the product.
+ *
+ * BlockRun publishes machine-readable prices at `/.well-known/x402`, so that
+ * is the source of truth here rather than constants scattered across tools
+ * (which had already drifted — surf.ts documented tiered $0.001/$0.005/$0.02
+ * against a catalog that says a flat $0.0085).
+ *
+ * Scope is deliberately narrow: **flat-rate service endpoints only**.
+ * Model-priced endpoints — chat, images, video, speech — are already costed by
+ * `gateway-models.ts` from the live model catalog, and that path works
+ * identically in both modes.
+ *
+ * Prices from this module are estimates. Callers must tag what they record so
+ * the audit trail never claims more precision than it has.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { BLOCKRUN_DIR, USER_AGENT } from '../config.js';
+
+/**
+ * The discovery doc is public, unauthenticated, and identical across the
+ * payment hosts, so it is always read from the Base origin — including in key
+ * mode, where `api.blockrun.ai` does not serve it.
+ */
+const CATALOG_URL = 'https://blockrun.ai/.well-known/x402';
+const CACHE_FILE = path.join(BLOCKRUN_DIR, 'price-catalog.json');
+const CACHE_TTL_MS = 6 * 60 * 60 * 1000; // prices move rarely; a stale read is cheap
+const FETCH_TIMEOUT_MS = 8_000;
+
+interface CatalogEntry {
+  /** Endpoint pattern as published, e.g. `/api/v1/surf/*`. */
+  endpoint: string;
+  /** USD per request, or 0 for a free endpoint. */
+  usd: number;
+}
+
+/**
+ * Offline floor, current as of 2026-09-05. Used before the first successful
+ * fetch and whenever the network is unavailable, so key mode never falls back
+ * to recording zero. Refreshed automatically from the live catalog.
+ */
+const STATIC_CATALOG: CatalogEntry[] = [
+  { endpoint: '/api/v1/surf/*', usd: 0.0085 },
+  { endpoint: '/api/v1/exa/contents', usd: 0.003 },
+  { endpoint: '/api/v1/exa/*', usd: 0.011 },
+  { endpoint: '/api/v1/rpc/{network}', usd: 0.003 },
+  { endpoint: '/api/v1/pm/*', usd: 0.0085 },
+  { endpoint: '/api/v1/defillama/*', usd: 0.006 },
+  { endpoint: '/api/v1/phone/*', usd: 0.011 },
+  { endpoint: '/api/v1/voice/call', usd: 0.541 },
+  { endpoint: '/api/v1/modal/sandbox/create', usd: 0.011 },
+  { endpoint: '/api/v1/modal/*', usd: 0.002 },
+  { endpoint: '/api/v1/realface/*', usd: 0.011 },
+  { endpoint: '/api/v1/portrait/*', usd: 0.011 },
+  { endpoint: '/api/v1/polymarket/fund', usd: 0.011 },
+  { endpoint: '/api/v1/usstock/price/{ticker}', usd: 0.002 },
+  { endpoint: '/api/v1/search', usd: 0.025 },
+  // Explicitly free — listed so a lookup returns 0 rather than "unknown",
+  // which would make callers fall back to a non-zero guess.
+  { endpoint: '/api/v1/zerox/*', usd: 0 },
+  { endpoint: '/api/v1/crypto/price/{pair}', usd: 0 },
+  { endpoint: '/api/v1/fx/price/{pair}', usd: 0 },
+  { endpoint: '/api/v1/commodity/price/{symbol}', usd: 0 },
+  { endpoint: '/api/v1/onramp/token', usd: 0 },
+  { endpoint: '/api/v1/models', usd: 0 },
+];
+
+let catalog: CatalogEntry[] = STATIC_CATALOG;
+let loadedAt = 0;
+let inFlight: Promise<void> | null = null;
+
+// ─── Price parsing ──────────────────────────────────────────────────────
+
+/** `"$0.0085"` / `"0.006"` / `0.003` → 0.0085 / 0.006 / 0.003. Null if unparseable. */
+function toUsd(value: unknown): number | null {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value !== 'string') return null;
+  const n = Number(value.replace(/^\$/, '').trim());
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Reduce one service's `pricing` object to a single per-request USD figure,
+ * plus any nested endpoint-specific overrides it declares.
+ *
+ * The catalog uses several shapes for the same idea — `perRequest`, `perCall`,
+ * `flat`, `tierN.perRequest`, and grouped `{ endpoints: [...] }` lists. Only
+ * flat-rate shapes are handled; per-model maps (chat, images, video, speech)
+ * return null because `gateway-models.ts` prices those from the model catalog.
+ */
+function parsePricing(
+  endpoint: string,
+  pricing: unknown,
+): CatalogEntry[] {
+  if (!pricing || typeof pricing !== 'object') return [];
+  const p = pricing as Record<string, unknown>;
+  const out: CatalogEntry[] = [];
+
+  if (p.free === true) return [{ endpoint, usd: 0 }];
+
+  const direct = toUsd(p.perRequest) ?? toUsd(p.perCall) ?? toUsd(p.flat) ?? toUsd(p.perUrl);
+  if (direct !== null) out.push({ endpoint, usd: direct });
+
+  // Live search is billed per source queried. Franklin's Search tool sends one
+  // source unless the caller widens it, so the single-source price is the
+  // floor. A multi-source call is under-counted rather than guessed at — the
+  // dashboard remains the authority on the exact figure.
+  const perSource = toUsd(p.pricePerSource);
+  if (perSource !== null) out.push({ endpoint, usd: perSource });
+
+  // Nested groups: { tier1: {...}, tier2: {...} } and
+  // { create: { perRequest, endpoint }, operations: { perRequest, endpoints: [] } }.
+  for (const [key, value] of Object.entries(p)) {
+    if (!value || typeof value !== 'object' || key === 'payment') continue;
+    const group = value as Record<string, unknown>;
+    const usd = toUsd(group.perRequest) ?? toUsd(group.perCall) ?? toUsd(group.perUrl);
+    if (usd === null) continue;
+
+    const own = typeof group.endpoint === 'string' ? [group.endpoint] : [];
+    const many = Array.isArray(group.endpoints)
+      ? group.endpoints.filter((e): e is string => typeof e === 'string')
+      : [];
+    const targets = [...own, ...many];
+
+    if (targets.length > 0) for (const t of targets) out.push({ endpoint: t, usd });
+    // A bare tier with no endpoint list prices the whole service. Take the
+    // dearest tier so an estimate errs toward over-counting, which is the safe
+    // direction for a spend ceiling.
+    else if (!out.some((e) => e.endpoint === endpoint && e.usd >= usd)) {
+      out.push({ endpoint, usd });
+    }
+  }
+
+  // A service listing per-endpoint prices as a flat array.
+  if (Array.isArray(p.endpoints)) {
+    for (const item of p.endpoints) {
+      if (!item || typeof item !== 'object') continue;
+      const row = item as Record<string, unknown>;
+      const usd = toUsd(row.perRequest) ?? toUsd(row.perCall);
+      if (typeof row.endpoint === 'string' && usd !== null) {
+        out.push({ endpoint: row.endpoint, usd });
+      }
+    }
+  }
+
+  return out;
+}
+
+// ─── Pattern matching ───────────────────────────────────────────────────
+
+/**
+ * Turn a published endpoint pattern into a matcher.
+ *
+ *   `/api/v1/surf/*`                          → any path under /surf/
+ *   `/api/v1/rpc/{network}`                   → one path segment
+ *   `/api/v1/pm/{limitless,opinion}/*`        → one of the listed segments
+ */
+function patternToRegExp(pattern: string): RegExp {
+  let src = '';
+  for (const part of pattern.split('/')) {
+    if (part === '') continue;
+    src += '/';
+    if (part === '*') {
+      src += '.*';
+    } else if (part.startsWith('{') && part.endsWith('}')) {
+      const inner = part.slice(1, -1);
+      // A brace group may itself contain slashes and nested braces, e.g.
+      // `{identity/{wallet},identities}` — too irregular to model exactly, so
+      // treat any such group as "one or more segments".
+      src += inner.includes(',') || inner.includes('/') ? '[^?]+' : '[^/?]+';
+    } else {
+      src += part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    }
+  }
+  return new RegExp(`^${src}/?$`);
+}
+
+/** Specificity: more literal segments and no wildcard wins. */
+function specificity(pattern: string): number {
+  const segments = pattern.split('/').filter(Boolean);
+  const literal = segments.filter((s) => s !== '*' && !s.startsWith('{')).length;
+  return literal * 10 - (pattern.includes('*') ? 1 : 0);
+}
+
+// ─── Cache ──────────────────────────────────────────────────────────────
+
+function readDiskCache(): void {
+  try {
+    const stat = fs.statSync(CACHE_FILE);
+    if (Date.now() - stat.mtimeMs > CACHE_TTL_MS) return;
+    const parsed = JSON.parse(fs.readFileSync(CACHE_FILE, 'utf-8')) as CatalogEntry[];
+    if (Array.isArray(parsed) && parsed.length > 0) {
+      catalog = parsed;
+      loadedAt = stat.mtimeMs;
+    }
+  } catch { /* no cache, or unreadable — the static floor covers it */ }
+}
+
+function writeDiskCache(entries: CatalogEntry[]): void {
+  try {
+    fs.mkdirSync(BLOCKRUN_DIR, { recursive: true });
+    fs.writeFileSync(CACHE_FILE, JSON.stringify(entries), { mode: 0o600 });
+  } catch { /* best-effort — an in-memory catalog still works */ }
+}
+
+async function fetchCatalog(): Promise<void> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(CATALOG_URL, {
+      signal: ctrl.signal,
+      headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' },
+    });
+    if (!res.ok) return;
+    const body = (await res.json()) as { services?: unknown };
+    if (!Array.isArray(body.services)) return;
+
+    const entries: CatalogEntry[] = [];
+    for (const svc of body.services) {
+      if (!svc || typeof svc !== 'object') continue;
+      const s = svc as Record<string, unknown>;
+      if (typeof s.endpoint !== 'string') continue;
+      entries.push(...parsePricing(s.endpoint, s.pricing));
+    }
+    if (entries.length === 0) return;
+
+    // Keep the static floor underneath so an endpoint the catalog stops
+    // listing does not silently become free.
+    const merged = new Map<string, number>();
+    for (const e of STATIC_CATALOG) merged.set(e.endpoint, e.usd);
+    for (const e of entries) merged.set(e.endpoint, e.usd);
+    catalog = [...merged].map(([endpoint, usd]) => ({ endpoint, usd }));
+    loadedAt = Date.now();
+    writeDiskCache(catalog);
+  } catch { /* offline — the static floor covers it */ } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Refresh the catalog in the background. Safe to call repeatedly; only one
+ * fetch is ever in flight and it is skipped while the cache is fresh.
+ */
+export function warmPriceCatalog(): void {
+  if (loadedAt === 0) readDiskCache();
+  if (Date.now() - loadedAt < CACHE_TTL_MS) return;
+  if (inFlight) return;
+  inFlight = fetchCatalog().finally(() => { inFlight = null; });
+}
+
+/** Test seam — drop the loaded catalog and fall back to the static floor. */
+export function __resetPriceCatalog(): void {
+  catalog = STATIC_CATALOG;
+  loadedAt = 0;
+  inFlight = null;
+}
+
+/** Test seam — install a catalog without touching the network or disk. */
+export function __primePriceCatalog(entries: CatalogEntry[]): void {
+  catalog = entries;
+  loadedAt = Date.now();
+}
+
+// ─── Lookup ─────────────────────────────────────────────────────────────
+
+/**
+ * List price in USD for one gateway path, or null when the path is not a
+ * flat-rate service endpoint (chat and the other model-priced endpoints land
+ * here, and are costed from the model catalog instead).
+ *
+ * `apiPath` may be a bare path or a full URL, with or without the `/api`
+ * prefix and with or without a query string — the two payment hosts differ on
+ * the prefix and callers should not have to care.
+ *
+ * Synchronous by design: it is called on the response path of every paid tool,
+ * where an await would serialise the accounting behind a network fetch. The
+ * catalog refreshes in the background via `warmPriceCatalog()`.
+ */
+export function priceForPath(apiPath: string): number | null {
+  warmPriceCatalog();
+
+  // Accept a bare path or a full gateway URL — call sites already hold the
+  // absolute endpoint they fetched, and making them slice it would just
+  // duplicate this logic 8 times.
+  let normalized = apiPath;
+  if (/^https?:\/\//.test(normalized)) {
+    try { normalized = new URL(normalized).pathname; } catch { /* fall through */ }
+  }
+  normalized = normalized.split('?')[0];
+  if (!normalized.startsWith('/')) normalized = '/' + normalized;
+  // The x402 hosts serve these routes under /api, the key host at the root.
+  // Catalog patterns use the /api form, so normalise onto that.
+  if (!normalized.startsWith('/api/')) normalized = '/api' + normalized;
+
+  let best: { usd: number; score: number } | null = null;
+  for (const entry of catalog) {
+    if (!patternToRegExp(entry.endpoint).test(normalized)) continue;
+    const score = specificity(entry.endpoint);
+    if (!best || score > best.score) best = { usd: entry.usd, score };
+  }
+  return best ? best.usd : null;
+}
+
+/**
+ * The amount to record for a completed paid call.
+ *
+ * `settledUsd` is the exact figure from an x402 settlement and always wins.
+ * `reportedUsd` is a charge the endpoint itself returned (Exa's `costDollars`).
+ * Otherwise the call is priced from the catalog — an estimate, flagged as such
+ * so `franklin stats` can render it honestly.
+ */
+export interface ResolvedCharge {
+  usd: number;
+  estimated: boolean;
+}
+
+export function resolveCharge(opts: {
+  apiPath: string;
+  settledUsd?: number;
+  reportedUsd?: number;
+  fallbackUsd?: number;
+}): ResolvedCharge {
+  const { apiPath, settledUsd, reportedUsd, fallbackUsd } = opts;
+  if (typeof settledUsd === 'number' && settledUsd > 0) {
+    return { usd: settledUsd, estimated: false };
+  }
+  if (typeof reportedUsd === 'number' && reportedUsd > 0) {
+    return { usd: reportedUsd, estimated: false };
+  }
+  const listed = priceForPath(apiPath);
+  if (listed !== null) return { usd: listed, estimated: true };
+  if (typeof fallbackUsd === 'number' && fallbackUsd > 0) {
+    return { usd: fallbackUsd, estimated: true };
+  }
+  return { usd: 0, estimated: true };
+}

--- a/src/phone/client.ts
+++ b/src/phone/client.ts
@@ -13,13 +13,17 @@
  *   - future Phone/Call tools surfaced to the agent
  */
 
-import { API_URLS, loadChain, type Chain } from '../config.js';
+import { loadChain, type Chain } from '../config.js';
+import { gatewayBase } from '../payments/auth-mode.js';
 import { postWithPayment } from '../payments/post-with-payment.js';
 import { recordUsage } from '../stats/tracker.js';
 import { writeCache, type PhoneNumberRecord } from './cache.js';
 
 function phoneEndpoint(chain: Chain, path: string): string {
-  return `${API_URLS[chain]}/v1/phone/${path}`;
+  // `chain` is retained for call-site clarity; the host itself comes from the
+  // active pay mode, which is chainless in API-key mode.
+  void chain;
+  return `${gatewayBase()}/v1/phone/${path}`;
 }
 
 // ─── Public API ─────────────────────────────────────────────────────────

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -10,6 +10,7 @@ import {
   SOLANA_NETWORK,
 } from '@blockrun/llm';
 import type { Chain } from '../config.js';
+import { applyGatewayAuth } from '../payments/auth-mode.js';
 import { recordUsage } from '../stats/tracker.js';
 // Single source of truth for shortcuts — shared with the /model picker so the
 // proxy can never drift from the interactive UI (it did before: grok→grok-3).
@@ -529,6 +530,17 @@ export function createProxy(options: ProxyOptions): http.Server {
             headers[key] = Array.isArray(value) ? value[0] : value;
           }
         }
+
+        // Applied AFTER the forwarding loop so our credential wins over
+        // whatever the proxied client sent. Anthropic-compatible clients
+        // routinely set their own `authorization` / `x-api-key`; in API-key
+        // mode those must not reach the gateway in place of Franklin's key.
+        // In wallet mode this contributes no auth at all and payment still
+        // rides on the PAYMENT-SIGNATURE header added on the 402 retry.
+        // applyGatewayAuth also strips the client's own Authorization header
+        // in every case variant — without that, fetch sends two of them and
+        // the gateway reads the wrong one (verified: 401 through the proxy).
+        applyGatewayAuth(headers);
 
         // Safety net: if requestModel is still a routing profile (blockrun/auto etc.)
         // after all resolution attempts, force-route it to a concrete model.

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -633,9 +633,10 @@ export async function llmClassifyRequest(prompt: string): Promise<Tier | null> {
   try {
     const llmMod = await import('../agent/llm.js');
     const cfgMod = await import('../config.js');
+    const authMod = await import('../payments/auth-mode.js');
     ModelClientCtor = llmMod.ModelClient;
     chain = cfgMod.loadChain();
-    apiUrl = cfgMod.API_URLS[chain];
+    apiUrl = authMod.gatewayBase();
   } catch {
     return null;
   }

--- a/src/serve/server.ts
+++ b/src/serve/server.ts
@@ -24,7 +24,8 @@ import path from 'node:path';
 // `ws` 8 moved the server class off the default export onto a named one. The
 // default import stays for the `WebSocket` type and its `OPEN` constant.
 import WebSocket, { WebSocketServer } from 'ws';
-import { loadChain, API_URLS, BLOCKRUN_DIR } from '../config.js';
+import { loadChain, BLOCKRUN_DIR} from '../config.js';
+import { gatewayBase, isKeyMode, loadApiKey, maskApiKey } from '../payments/auth-mode.js';
 import { loadConfig, setConfigValue } from '../commands/config.js';
 import { assembleInstructions } from '../agent/context.js';
 import { interactiveSession } from '../agent/loop.js';
@@ -392,7 +393,7 @@ export async function startServer(opts: ServerOptions): Promise<void> {
   let { port } = opts;
   const { workDir, debug } = opts;
   const chain = loadChain();
-  const apiUrl = API_URLS[chain];
+  const apiUrl = gatewayBase();
   const userConfig = loadConfig();
   const desktopBoundary = process.env.FRANKLIN_DESKTOP_WORKSPACE_BOUNDARY === '1';
   const desktopPermissionPolicy = desktopBoundary
@@ -722,7 +723,13 @@ export async function startServer(opts: ServerOptions): Promise<void> {
           // string instead of accidentally serializing a pending Promise as {}.
           const address = await client.getWalletAddress();
           const balanceUsd = await fetchBalanceUsd(); // best-effort; undefined on failure
-          send(ws, id, 'response', { address, chain, balanceUsd });
+          // The wallet still exists in API-key mode, but it is not what pays.
+          // Ship the active mode so the panel does not present a wallet balance
+          // as the spending source when spend is coming out of prepaid credit.
+          const key = loadApiKey();
+          const payMode = isKeyMode() ? 'api-key' : 'wallet';
+          const apiKeyMasked = isKeyMode() && key ? maskApiKey(key) : undefined;
+          send(ws, id, 'response', { address, chain, balanceUsd, payMode, apiKeyMasked });
         } catch (err) {
           send(ws, id, 'error', { message: err instanceof Error ? err.message : 'wallet error' });
         }

--- a/src/stats/tracker.ts
+++ b/src/stats/tracker.ts
@@ -8,6 +8,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { OPUS_PRICING } from '../pricing.js';
 import { BLOCKRUN_DIR } from '../config.js';
+import { isKeyMode } from '../payments/auth-mode.js';
 import { isTestFixtureModel } from './test-fixture.js';
 import { atomicWriteFileSync } from '../storage/atomic.js';
 
@@ -93,6 +94,12 @@ export interface Stats {
   version: number;
   totalRequests: number;
   totalCostUsd: number;
+  /**
+   * Portion of totalCostUsd that is a list-price estimate rather than a
+   * settled x402 amount. Non-zero only in API-key mode, where the gateway
+   * reports no per-call charge.
+   */
+  totalEstimatedCostUsd: number;
   totalInputTokens: number;
   totalOutputTokens: number;
   totalFallbacks: number;
@@ -107,6 +114,7 @@ const EMPTY_STATS: Stats = {
   version: 1,
   totalRequests: 0,
   totalCostUsd: 0,
+  totalEstimatedCostUsd: 0,
   totalInputTokens: 0,
   totalOutputTokens: 0,
   totalFallbacks: 0,
@@ -125,7 +133,7 @@ function parseStatsFile(file: string): Stats | null {
     // every downstream `history.push` / `Object.values(byModel)` would throw.
     if (!Array.isArray(merged.history)) merged.history = [];
     if (!merged.byModel || typeof merged.byModel !== 'object' || Array.isArray(merged.byModel)) merged.byModel = {};
-    const numKeys = ['totalRequests', 'totalCostUsd', 'totalInputTokens', 'totalOutputTokens', 'totalFallbacks'] as const;
+    const numKeys = ['totalRequests', 'totalCostUsd', 'totalEstimatedCostUsd', 'totalInputTokens', 'totalOutputTokens', 'totalFallbacks'] as const;
     for (const k of numKeys) {
       if (!Number.isFinite(merged[k])) merged[k] = 0;
     }
@@ -233,7 +241,15 @@ export function recordUsage(
   outputTokens: number,
   costUsd: number,
   latencyMs: number,
-  fallback: boolean = false
+  fallback: boolean = false,
+  /**
+   * Whether `costUsd` is a list-price estimate rather than an exact settled
+   * amount. Defaults to the active pay mode: an x402 settlement reports the
+   * real figure, while the API-key gateway returns no charge at all, so every
+   * key-mode row is priced locally. Surfaced by `franklin stats` so the ledger
+   * never claims more precision than it has.
+   */
+  estimated: boolean = isKeyMode()
 ): void {
   // Count real spend BEFORE the test/audit gates — the --max-spend ceiling must
   // see every paid tool call even when history persistence is suppressed.
@@ -256,6 +272,7 @@ export function recordUsage(
   // Update totals
   stats.totalRequests++;
   stats.totalCostUsd += costUsd;
+  if (estimated) stats.totalEstimatedCostUsd += costUsd;
   stats.totalInputTokens += inputTokens;
   stats.totalOutputTokens += outputTokens;
   if (fallback) stats.totalFallbacks++;

--- a/src/tools/blockrun.ts
+++ b/src/tools/blockrun.ts
@@ -29,7 +29,9 @@ import {
   SOLANA_NETWORK,
 } from '@blockrun/llm';
 import type { CapabilityHandler, CapabilityResult, ExecutionScope } from '../agent/types.js';
-import { loadChain, API_URLS, USER_AGENT } from '../config.js';
+import { loadChain, USER_AGENT} from '../config.js';
+import { resolveCharge } from '../payments/price-catalog.js';
+import { gatewayBase, gatewayHeaders } from '../payments/auth-mode.js';
 import { recordUsage } from '../stats/tracker.js';
 import { logger } from '../logger.js';
 
@@ -148,6 +150,7 @@ async function callGateway(
   const start = Date.now();
   const chain = loadChain();
   const headers: Record<string, string> = {
+    ...gatewayHeaders(),
     'Accept': 'application/json',
     'User-Agent': USER_AGENT,
   };
@@ -201,7 +204,7 @@ async function callGateway(
 
 function buildUrl(path: string, params: Record<string, unknown> | undefined): string {
   const chain = loadChain();
-  const base = API_URLS[chain]; // ends in /api
+  const base = gatewayBase(); // wallet host ends in /api; the key host does not
   const clean = path.startsWith('/') ? path : `/${path}`;
   const url = `${base}${clean}`;
   if (!params || Object.keys(params).length === 0) return url;
@@ -313,7 +316,11 @@ export const blockrunCapability: CapabilityHandler = {
 
     // Telemetry — show in the panel Audit tab regardless of success
     try {
-      recordUsage(`BlockRun:${path}`, 0, 0, result.paidUsd, result.latencyMs);
+      // `paidUsd` comes from the 402 settlement and is 0 in API-key mode,
+      // where the gateway charges without a handshake. Price from the catalog
+      // so raw gateway calls still count against --max-spend.
+      const charge = resolveCharge({ apiPath: path, settledUsd: result.paidUsd });
+      recordUsage(`BlockRun:${path}`, 0, 0, charge.usd, result.latencyMs, false, charge.estimated);
     } catch { /* best-effort */ }
 
     if (!result.ok) {

--- a/src/tools/defillama.ts
+++ b/src/tools/defillama.ts
@@ -27,7 +27,9 @@ import {
   SOLANA_NETWORK,
 } from '@blockrun/llm';
 import type { CapabilityHandler, CapabilityResult, ExecutionScope } from '../agent/types.js';
-import { loadChain, API_URLS, VERSION } from '../config.js';
+import { loadChain, VERSION} from '../config.js';
+import { resolveCharge } from '../payments/price-catalog.js';
+import { gatewayBase, gatewayHeaders } from '../payments/auth-mode.js';
 import { logger } from '../logger.js';
 import { recordUsage } from '../stats/tracker.js';
 import { frameUntrusted } from './untrusted.js';
@@ -38,9 +40,10 @@ const TIMEOUT_MS = 30_000;
 
 async function getWithPayment<T>(path: string, ctx: ExecutionScope): Promise<T> {
   const chain = loadChain();
-  const apiUrl = API_URLS[chain];
+  const apiUrl = gatewayBase();
   const endpoint = `${apiUrl}${path}`;
   const headers: Record<string, string> = {
+    ...gatewayHeaders(),
     Accept: 'application/json',
     'User-Agent': `franklin/${VERSION}`,
   };
@@ -79,7 +82,10 @@ async function getWithPayment<T>(path: string, ctx: ExecutionScope): Promise<T> 
 
     // Record the settled x402 spend so DeFiLlama calls show up in franklin
     // stats / audit AND count against the --max-spend ceiling (parity with surf.ts).
-    try { recordUsage(`DeFiLlama:${path}`, 0, 0, paidUsd, Date.now() - startedAt); } catch { /* best-effort */ }
+    // See rpc.ts — `paidUsd` is 0 whenever no 402 happened, which is every
+    // call in API-key mode.
+    const charge = resolveCharge({ apiPath: endpoint, settledUsd: paidUsd });
+    try { recordUsage(`DeFiLlama:${path}`, 0, 0, charge.usd, Date.now() - startedAt, false, charge.estimated); } catch { /* best-effort */ }
     return (await response.json()) as T;
   } finally {
     clearTimeout(timeout);

--- a/src/tools/exa.ts
+++ b/src/tools/exa.ts
@@ -29,7 +29,9 @@ import {
   SOLANA_NETWORK,
 } from '@blockrun/llm';
 import type { CapabilityHandler, CapabilityResult, ExecutionScope } from '../agent/types.js';
-import { loadChain, API_URLS, VERSION } from '../config.js';
+import { loadChain, VERSION} from '../config.js';
+import { resolveCharge } from '../payments/price-catalog.js';
+import { gatewayBase, gatewayHeaders } from '../payments/auth-mode.js';
 import { frameUntrusted } from './untrusted.js';
 import { recordUsage } from '../stats/tracker.js';
 import { logger } from '../logger.js';
@@ -50,10 +52,11 @@ async function postWithPayment<T>(
   ctx: ExecutionScope,
 ): Promise<PaidResponse<T>> {
   const chain = loadChain();
-  const apiUrl = API_URLS[chain];
+  const apiUrl = gatewayBase();
   const endpoint = `${apiUrl}${path}`;
   const bodyStr = JSON.stringify(body);
   const headers: Record<string, string> = {
+    ...gatewayHeaders(),
     'Content-Type': 'application/json',
     'User-Agent': `franklin/${VERSION}`,
   };
@@ -100,14 +103,24 @@ async function postWithPayment<T>(
   }
 }
 
-// Fold a settled Exa charge into the live-spend accumulator so it counts against
+// Fold an Exa charge into the live-spend accumulator so it counts against
 // --max-spend and shows in stats — exactly like surf.ts / blockrun.ts. Without
-// this, every Exa tool spent real USDC invisibly to the budget ceiling. Use the
-// gateway-reported charge when present, else the tool's list price as a floor.
+// this, every Exa tool spent real USDC invisibly to the budget ceiling.
+//
+// `settled` is true only when an x402 handshake happened. It is false on two
+// very different paths: a genuinely free 200, and every API-key call, where the
+// gateway charges the prepaid balance without a 402. Exa itself returns
+// `costDollars`, so prefer that; otherwise price from the catalog. Returning
+// early on !settled — as this did before key mode — would record $0 for real
+// spend.
 function recordExaSpend(path: string, settled: boolean, reportedUsd: number | undefined, fallbackUsd: number, latencyMs: number): void {
-  if (!settled) return; // free/already-paid (200-first) path — no charge to record
-  const usd = typeof reportedUsd === 'number' && reportedUsd > 0 ? reportedUsd : fallbackUsd;
-  try { recordUsage(`Exa:${path}`, 0, 0, usd, latencyMs); } catch { /* best-effort accounting */ }
+  const charge = settled
+    // Settled through x402: the gateway-reported charge, else the list price.
+    // Either way it reflects money that demonstrably moved.
+    ? { usd: reportedUsd && reportedUsd > 0 ? reportedUsd : fallbackUsd, estimated: false }
+    : resolveCharge({ apiPath: path, reportedUsd, fallbackUsd });
+  if (charge.usd <= 0) return;
+  try { recordUsage(`Exa:${path}`, 0, 0, charge.usd, latencyMs, false, charge.estimated); } catch { /* best-effort accounting */ }
 }
 
 async function signPayment(

--- a/src/tools/imagegen.ts
+++ b/src/tools/imagegen.ts
@@ -16,7 +16,8 @@ import {
   SOLANA_NETWORK,
 } from '@blockrun/llm';
 import type { CapabilityHandler, CapabilityResult, ExecutionScope } from '../agent/types.js';
-import { loadChain, API_URLS, VERSION } from '../config.js';
+import { loadChain, VERSION} from '../config.js';
+import { gatewayBase, gatewayHeaders } from '../payments/auth-mode.js';
 import type { ContentLibrary } from '../content/library.js';
 import { checkImageBudget, recordImageAsset } from '../content/record-image.js';
 import { estimateImageCostUsd } from '../content/image-pricing.js';
@@ -393,7 +394,7 @@ function buildExecute(deps: ImageGenDeps) {
     }
 
   const chain = loadChain();
-  const apiUrl = API_URLS[chain];
+  const apiUrl = gatewayBase();
   // Reference-image mode hits the dedicated /v1/images/image2image endpoint;
   // otherwise stay on text-to-image generations.
   const endpoint = editMode
@@ -433,6 +434,7 @@ function buildExecute(deps: ImageGenDeps) {
   );
 
   const headers: Record<string, string> = {
+    ...gatewayHeaders(),
     'Content-Type': 'application/json',
     'User-Agent': `franklin/${VERSION}`,
   };

--- a/src/tools/modal.ts
+++ b/src/tools/modal.ts
@@ -37,7 +37,8 @@ import {
   SOLANA_NETWORK,
 } from '@blockrun/llm';
 import type { CapabilityHandler, CapabilityResult, ExecutionScope } from '../agent/types.js';
-import { loadChain, API_URLS, VERSION } from '../config.js';
+import { loadChain, VERSION} from '../config.js';
+import { gatewayBase, gatewayHeaders } from '../payments/auth-mode.js';
 import { walletReservation, AMBIGUOUS_GRACE_MS, type ReservationToken } from '../wallet/reservation.js';
 import { recordUsage } from '../stats/tracker.js';
 import { logger } from '../logger.js';
@@ -201,6 +202,7 @@ export async function postWithPayment(
 ): Promise<{ ok: boolean; status: number; body: Record<string, unknown>; raw: string }> {
   const chain = loadChain();
   const headers: Record<string, string> = {
+    ...gatewayHeaders(),
     'Content-Type': 'application/json',
     'User-Agent': `franklin/${VERSION}`,
   };
@@ -302,7 +304,7 @@ function definitelyNotSent(err: unknown): boolean {
 
 function modalEndpoint(path: string): string {
   const chain = loadChain();
-  return `${API_URLS[chain]}/v1/modal/sandbox/${path}`;
+  return `${gatewayBase()}/v1/modal/sandbox/${path}`;
 }
 
 /**

--- a/src/tools/musicgen.ts
+++ b/src/tools/musicgen.ts
@@ -27,7 +27,8 @@ import {
   SOLANA_NETWORK,
 } from '@blockrun/llm';
 import type { CapabilityHandler, CapabilityResult, ExecutionScope } from '../agent/types.js';
-import { loadChain, API_URLS, VERSION } from '../config.js';
+import { loadChain, VERSION} from '../config.js';
+import { gatewayBase, gatewayHeaders } from '../payments/auth-mode.js';
 import { logger } from '../logger.js';
 import type { ContentLibrary } from '../content/library.js';
 import { isWalletKeyPath } from './sensitive-paths.js';
@@ -114,7 +115,7 @@ function buildExecute(deps: MusicGenDeps) {
     }
 
     const chain = loadChain();
-    const apiUrl = API_URLS[chain];
+    const apiUrl = gatewayBase();
     const endpoint = `${apiUrl}/v1/audio/generations`;
 
     const outPath = output_path
@@ -134,6 +135,7 @@ function buildExecute(deps: MusicGenDeps) {
     });
 
     const headers: Record<string, string> = {
+      ...gatewayHeaders(),
       'Content-Type': 'application/json',
       'User-Agent': `franklin/${VERSION}`,
     };

--- a/src/tools/phone.ts
+++ b/src/tools/phone.ts
@@ -23,7 +23,8 @@ import {
   SOLANA_NETWORK,
 } from '@blockrun/llm';
 import type { CapabilityHandler, CapabilityResult, ExecutionScope } from '../agent/types.js';
-import { loadChain, API_URLS, VERSION } from '../config.js';
+import { loadChain, VERSION} from '../config.js';
+import { gatewayBase, gatewayHeaders } from '../payments/auth-mode.js';
 import { logger } from '../logger.js';
 import { recordUsage } from '../stats/tracker.js';
 
@@ -51,10 +52,11 @@ async function postWithPayment<T>(
 ): Promise<T> {
   const startMs = Date.now();
   const chain = loadChain();
-  const apiUrl = API_URLS[chain];
+  const apiUrl = gatewayBase();
   const endpoint = `${apiUrl}${path}`;
   const bodyStr = JSON.stringify(body);
   const headers: Record<string, string> = {
+    ...gatewayHeaders(),
     'Content-Type': 'application/json',
     'User-Agent': `franklin/${VERSION}`,
   };

--- a/src/tools/prediction.ts
+++ b/src/tools/prediction.ts
@@ -47,7 +47,9 @@ import {
   SOLANA_NETWORK,
 } from '@blockrun/llm';
 import type { CapabilityHandler, CapabilityResult, ExecutionScope } from '../agent/types.js';
-import { loadChain, API_URLS, VERSION } from '../config.js';
+import { loadChain, VERSION} from '../config.js';
+import { resolveCharge } from '../payments/price-catalog.js';
+import { gatewayBase, gatewayHeaders } from '../payments/auth-mode.js';
 import { logger } from '../logger.js';
 import { recordFetch } from '../trading/providers/telemetry.js';
 import { recordUsage } from '../stats/tracker.js';
@@ -82,7 +84,7 @@ function priceForPath(path: string): number {
 
 async function getWithPayment<T>(path: string, query: Record<string, string | number | undefined>, ctx: ExecutionScope): Promise<T> {
   const chain = loadChain();
-  const apiUrl = API_URLS[chain];
+  const apiUrl = gatewayBase();
   const qs = new URLSearchParams();
   for (const [k, v] of Object.entries(query)) {
     if (v == null || v === '') continue;
@@ -91,6 +93,7 @@ async function getWithPayment<T>(path: string, query: Record<string, string | nu
   const queryStr = qs.toString();
   const endpoint = `${apiUrl}${path}${queryStr ? `?${queryStr}` : ''}`;
   const headers: Record<string, string> = {
+    ...gatewayHeaders(),
     Accept: 'application/json',
     'User-Agent': `franklin/${VERSION}`,
   };
@@ -127,17 +130,26 @@ async function getWithPayment<T>(path: string, query: Record<string, string | nu
       throw new Error(`PredictionMarket ${path} failed (${response.status}): ${errText.slice(0, 600)}`);
     }
 
+    // `costRecorded` is only set on the post-402 settlement, so it is 0 for
+    // every call in API-key mode, where the gateway charges silently. Fall back
+    // to this module's own price table, then to the published catalog.
+    const charge = resolveCharge({
+      apiPath: endpoint,
+      settledUsd: costRecorded,
+      fallbackUsd: priceForPath(path),
+    });
+
     recordFetch({
       provider: 'blockrun',
       endpoint: path,
       ok: true,
       latencyMs: Date.now() - startedAt,
-      costUsd: costRecorded > 0 ? costRecorded : undefined,
+      costUsd: charge.usd > 0 ? charge.usd : undefined,
     });
     // ALSO persist to franklin-stats (recordFetch is in-memory only, lost on
     // restart). Without this, Predexon spend is absent from `franklin stats`
     // and invisible to the --max-spend ceiling (parity with surf.ts).
-    try { recordUsage(`PredictionMarket:${path}`, 0, 0, costRecorded, Date.now() - startedAt); } catch { /* best-effort */ }
+    try { recordUsage(`PredictionMarket:${path}`, 0, 0, charge.usd, Date.now() - startedAt, false, charge.estimated); } catch { /* best-effort */ }
     return (await response.json()) as T;
   } finally {
     clearTimeout(timeout);

--- a/src/tools/realface.ts
+++ b/src/tools/realface.ts
@@ -37,7 +37,9 @@ import {
   SOLANA_NETWORK,
 } from '@blockrun/llm';
 import type { CapabilityHandler, CapabilityResult, ExecutionScope } from '../agent/types.js';
-import { loadChain, API_URLS, USER_AGENT } from '../config.js';
+import { loadChain, USER_AGENT} from '../config.js';
+import { resolveCharge } from '../payments/price-catalog.js';
+import { gatewayBase, gatewayHeaders } from '../payments/auth-mode.js';
 import { recordUsage } from '../stats/tracker.js';
 import { logger } from '../logger.js';
 
@@ -146,7 +148,7 @@ async function actionInit(base: string, input: Record<string, unknown>, ctx: Exe
   const body = JSON.stringify(groupId ? { name, groupId } : { name });
   const res = await timedFetch(`${base}/v1/realface/init`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', Accept: 'application/json', 'User-Agent': USER_AGENT },
+    headers: { ...gatewayHeaders(), 'Content-Type': 'application/json', Accept: 'application/json', 'User-Agent': USER_AGENT },
     body,
   }, ctx);
   const raw = await res.text().catch(() => '');
@@ -172,7 +174,7 @@ async function actionStatus(base: string, input: Record<string, unknown>, ctx: E
     if (ctx.abortSignal.aborted) break;
     const res = await timedFetch(`${base}/v1/realface/status?groupId=${encodeURIComponent(groupId)}`, {
       method: 'GET',
-      headers: { Accept: 'application/json', 'User-Agent': USER_AGENT },
+      headers: { ...gatewayHeaders(), Accept: 'application/json', 'User-Agent': USER_AGENT },
     }, ctx);
     raw = await res.text().catch(() => '');
     if (!res.ok) return { output: `RealFace status failed (status ${res.status}).\n${raw.slice(0, 600)}`, isError: true };
@@ -207,7 +209,7 @@ async function actionEnroll(
 
   const url = `${base}/v1/realface/enroll`;
   const body = JSON.stringify({ name, image_url: imageUrl, group_id: groupId });
-  const headers: Record<string, string> = { 'Content-Type': 'application/json', Accept: 'application/json', 'User-Agent': USER_AGENT };
+  const headers: Record<string, string> = { ...gatewayHeaders(), 'Content-Type': 'application/json', Accept: 'application/json', 'User-Agent': USER_AGENT };
   const start = Date.now();
 
   let res = await timedFetch(url, { method: 'POST', headers, body }, ctx);
@@ -220,7 +222,11 @@ async function actionEnroll(
   }
   const raw = await res.text().catch(() => '');
   if (!res.ok) paidUsd = 0;
-  try { recordUsage('RealFace:enroll', 0, 0, paidUsd, Date.now() - start); } catch { /* best-effort */ }
+  // 0 whenever no 402 was settled, which is every call in API-key mode.
+  const charge = res.ok
+    ? resolveCharge({ apiPath: url, settledUsd: paidUsd })
+    : { usd: 0, estimated: false };
+  try { recordUsage('RealFace:enroll', 0, 0, charge.usd, Date.now() - start, false, charge.estimated); } catch { /* best-effort */ }
 
   if (res.status === 425) {
     return { output: `RealFace enroll: the group isn't active yet — the person must finish the phone liveness check first. No payment taken. Poll action="status" until active, then retry.\n${raw.slice(0, 600)}`, isError: true };
@@ -233,7 +239,7 @@ async function actionEnroll(
   }
   return {
     output:
-      `RealFace enrolled → $${paidUsd.toFixed(4)} · ${Date.now() - start}ms. ` +
+      `RealFace enrolled → $${charge.usd.toFixed(4)} · ${Date.now() - start}ms. ` +
       `Use the returned \`asset_id\` (ta_xxx) as \`real_face_asset_id\` on a VideoGen call with ` +
       `bytedance/seedance-2.0 or -fast for a real-person clip.${fence(raw)}`,
   };
@@ -243,7 +249,7 @@ async function actionList(base: string, chain: 'base' | 'solana', ctx: Execution
   const addr = await walletAddress(chain);
   const res = await timedFetch(`${base}/v1/wallet/${addr}/realfaces`, {
     method: 'GET',
-    headers: { Accept: 'application/json', 'User-Agent': USER_AGENT },
+    headers: { ...gatewayHeaders(), Accept: 'application/json', 'User-Agent': USER_AGENT },
   }, ctx);
   const raw = await res.text().catch(() => '');
   if (!res.ok) return { output: `RealFace list failed (status ${res.status}).\n${raw.slice(0, 600)}`, isError: true };
@@ -253,7 +259,7 @@ async function actionList(base: string, chain: 'base' | 'solana', ctx: Execution
 async function execute(input: Record<string, unknown>, ctx: ExecutionScope): Promise<CapabilityResult> {
   const action = typeof input.action === 'string' ? input.action.trim() : '';
   const chain = loadChain();
-  const base = API_URLS[chain]; // ends in /api
+  const base = gatewayBase(); // wallet host ends in /api; the key host does not
   switch (action) {
     case 'init': return actionInit(base, input, ctx);
     case 'status': return actionStatus(base, input, ctx);

--- a/src/tools/rpc.ts
+++ b/src/tools/rpc.ts
@@ -28,7 +28,9 @@ import {
   SOLANA_NETWORK,
 } from '@blockrun/llm';
 import type { CapabilityHandler, CapabilityResult, ExecutionScope } from '../agent/types.js';
-import { loadChain, API_URLS, VERSION } from '../config.js';
+import { loadChain, VERSION} from '../config.js';
+import { resolveCharge } from '../payments/price-catalog.js';
+import { gatewayBase, gatewayHeaders } from '../payments/auth-mode.js';
 import { logger } from '../logger.js';
 import { recordUsage } from '../stats/tracker.js';
 
@@ -76,10 +78,11 @@ async function postRpcWithPayment(
   ctx: ExecutionScope,
 ): Promise<RpcCallResult> {
   const chain = loadChain();
-  const apiUrl = API_URLS[chain];
+  const apiUrl = gatewayBase();
   const endpoint = `${apiUrl}/v1/rpc/${network}`;
   const bodyStr = JSON.stringify(jsonRpcBody);
   const headers: Record<string, string> = {
+    ...gatewayHeaders(),
     'Content-Type': 'application/json',
     Accept: 'application/json',
     'User-Agent': `franklin/${VERSION}`,
@@ -121,7 +124,11 @@ async function postRpcWithPayment(
 
     // Record the settled x402 spend so RPC calls show up in franklin stats /
     // audit AND count against the --max-spend ceiling (parity with surf.ts).
-    try { recordUsage(`MultiChainRPC:${network}`, 0, 0, paidUsd, Date.now() - startedAt); } catch { /* best-effort */ }
+    // `paidUsd` is only ever set by the 402 branch, so in API-key mode — where
+    // the gateway settles silently and never sends a 402 — it stays 0. Price the
+    // call from the published catalog instead of recording a free call.
+    const charge = resolveCharge({ apiPath: endpoint, settledUsd: paidUsd });
+    try { recordUsage(`MultiChainRPC:${network}`, 0, 0, charge.usd, Date.now() - startedAt, false, charge.estimated); } catch { /* best-effort */ }
     return {
       body: await response.json(),
       network: response.headers.get('x-network') || network,

--- a/src/tools/surf.ts
+++ b/src/tools/surf.ts
@@ -27,7 +27,9 @@ import {
   SOLANA_NETWORK,
 } from '@blockrun/llm';
 import type { CapabilityHandler, CapabilityResult, ExecutionScope } from '../agent/types.js';
-import { loadChain, API_URLS, USER_AGENT } from '../config.js';
+import { loadChain, USER_AGENT} from '../config.js';
+import { resolveCharge } from '../payments/price-catalog.js';
+import { gatewayBase, gatewayHeaders } from '../payments/auth-mode.js';
 import { frameUntrusted } from './untrusted.js';
 import { recordUsage } from '../stats/tracker.js';
 import { logger } from '../logger.js';
@@ -207,7 +209,7 @@ async function callSurf(
   }
 
   const chain = loadChain();
-  const base = API_URLS[chain]; // ends in /api
+  const base = gatewayBase(); // wallet host ends in /api; the key host does not
   let url = `${base}/v1/surf/${entry.path}`;
   const body = entry.method === 'POST'
     ? (input.body && typeof input.body === 'object' ? input.body as Record<string, unknown> : query)
@@ -226,7 +228,7 @@ async function callSurf(
   const onAbort = () => ctrl.abort();
   ctx.abortSignal.addEventListener('abort', onAbort, { once: true });
   const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
-  const headers: Record<string, string> = { Accept: 'application/json', 'User-Agent': USER_AGENT };
+  const headers: Record<string, string> = { ...gatewayHeaders(), Accept: 'application/json', 'User-Agent': USER_AGENT };
   if (entry.method === 'POST') headers['Content-Type'] = 'application/json';
   const payload = body !== undefined ? JSON.stringify(body) : undefined;
   const resourceDescription = `Surf ${entry.method} /v1/surf/${entry.path}`;
@@ -245,7 +247,13 @@ async function callSurf(
     }
     if (!response.ok) paidUsd = 0;
     const raw = await response.text().catch(() => '');
-    try { recordUsage(`${toolName}:${entry.path}`, 0, 0, paidUsd, Date.now() - start); } catch { /* best-effort */ }
+    // `paidUsd` is 0 unless a 402 was settled — i.e. always 0 in API-key mode.
+    // Fall back to the catalog price so Surf spend still counts against
+    // --max-spend and shows in stats.
+    const charge = response.ok
+      ? resolveCharge({ apiPath: url, settledUsd: paidUsd })
+      : { usd: 0, estimated: false };
+    try { recordUsage(`${toolName}:${entry.path}`, 0, 0, charge.usd, Date.now() - start, false, charge.estimated); } catch { /* best-effort */ }
 
     if (!response.ok) {
       return {

--- a/src/tools/videogen.ts
+++ b/src/tools/videogen.ts
@@ -33,7 +33,8 @@ import {
   SOLANA_NETWORK,
 } from '@blockrun/llm';
 import type { CapabilityHandler, CapabilityResult, ExecutionScope } from '../agent/types.js';
-import { loadChain, API_URLS, VERSION } from '../config.js';
+import { loadChain, VERSION} from '../config.js';
+import { gatewayBase, gatewayHeaders } from '../payments/auth-mode.js';
 import { logger } from '../logger.js';
 import type { ContentLibrary } from '../content/library.js';
 import { resolveReferenceImage } from './imagegen.js';
@@ -207,7 +208,7 @@ function buildExecute(deps: VideoGenDeps) {
     }
 
     const chain = loadChain();
-    const apiUrl = API_URLS[chain];
+    const apiUrl = gatewayBase();
     const endpoint = `${apiUrl}/v1/videos/generations`;
 
     const outPath = output_path
@@ -236,6 +237,7 @@ function buildExecute(deps: VideoGenDeps) {
     });
 
     const headers: Record<string, string> = {
+      ...gatewayHeaders(),
       'Content-Type': 'application/json',
       'User-Agent': `franklin/${VERSION}`,
     };

--- a/src/tools/voice.ts
+++ b/src/tools/voice.ts
@@ -26,7 +26,8 @@ import {
   SOLANA_NETWORK,
 } from '@blockrun/llm';
 import type { CapabilityHandler, CapabilityResult, ExecutionScope } from '../agent/types.js';
-import { loadChain, API_URLS, VERSION } from '../config.js';
+import { loadChain, VERSION} from '../config.js';
+import { gatewayBase, gatewayHeaders } from '../payments/auth-mode.js';
 import { logger } from '../logger.js';
 import { recordUsage } from '../stats/tracker.js';
 import { frameUntrusted } from './untrusted.js';
@@ -77,10 +78,11 @@ async function postWithPayment<T>(
 ): Promise<T> {
   const startMs = Date.now();
   const chain = loadChain();
-  const apiUrl = API_URLS[chain];
+  const apiUrl = gatewayBase();
   const endpoint = `${apiUrl}${path}`;
   const bodyStr = JSON.stringify(body);
   const headers: Record<string, string> = {
+    ...gatewayHeaders(),
     'Content-Type': 'application/json',
     'User-Agent': `franklin/${VERSION}`,
   };
@@ -129,7 +131,7 @@ async function postWithPayment<T>(
 async function getNoPayment<T>(path: string, ctx: ExecutionScope, meta: PaidCallMeta, record = true): Promise<T> {
   const startMs = Date.now();
   const chain = loadChain();
-  const apiUrl = API_URLS[chain];
+  const apiUrl = gatewayBase();
   const endpoint = `${apiUrl}${path}`;
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), VOICE_TIMEOUT_MS);
@@ -139,7 +141,7 @@ async function getNoPayment<T>(path: string, ctx: ExecutionScope, meta: PaidCall
     const resp = await fetch(endpoint, {
       method: 'GET',
       signal: controller.signal,
-      headers: { 'User-Agent': `franklin/${VERSION}` },
+      headers: { ...gatewayHeaders(), 'User-Agent': `franklin/${VERSION}` },
     });
     if (!resp.ok) {
       const errText = await resp.text().catch(() => '');

--- a/src/tools/zerox-base.ts
+++ b/src/tools/zerox-base.ts
@@ -42,7 +42,8 @@ import { base } from 'viem/chains';
 import { getOrCreateWallet } from '@blockrun/llm';
 
 import { loadConfig } from '../commands/config.js';
-import { loadChain, API_URLS, VERSION } from '../config.js';
+import { gatewayBase, gatewayHeaders } from '../payments/auth-mode.js';
+import { loadChain, VERSION} from '../config.js';
 import { appendSwap } from '../stats/swap-log.js';
 import type { CapabilityHandler, ExecutionScope } from '../agent/types.js';
 
@@ -236,9 +237,10 @@ async function gatewayGet<T>(
   ctx: ExecutionScope,
 ): Promise<T> {
   const chain = loadChain();
-  const apiUrl = API_URLS[chain];
+  const apiUrl = gatewayBase();
   const endpoint = `${apiUrl}${ZEROX_GATEWAY_PATH}/${path}?${params.toString()}`;
   const headers: Record<string, string> = {
+    ...gatewayHeaders(),
     Accept: 'application/json',
     'User-Agent': `franklin/${VERSION}`,
   };

--- a/src/tools/zerox-gasless.ts
+++ b/src/tools/zerox-gasless.ts
@@ -31,7 +31,8 @@ import { createWalletClient, http, publicActions } from 'viem';
 import { getOrCreateWallet } from '@blockrun/llm';
 
 import { loadConfig } from '../commands/config.js';
-import { loadChain, API_URLS, VERSION } from '../config.js';
+import { gatewayBase, gatewayHeaders } from '../payments/auth-mode.js';
+import { loadChain, VERSION} from '../config.js';
 import { appendSwap } from '../stats/swap-log.js';
 import { logger } from '../logger.js';
 import type { CapabilityHandler, ExecutionScope } from '../agent/types.js';
@@ -215,7 +216,7 @@ async function gatewayGet<T>(
   timeoutMs: number,
   ctx: ExecutionScope,
 ): Promise<T> {
-  const apiUrl = API_URLS[loadChain()];
+  const apiUrl = gatewayBase();
   const url = `${apiUrl}${ZEROX_GATEWAY_PATH}/${pathSuffix}?${query.toString()}`;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -224,7 +225,7 @@ async function gatewayGet<T>(
   try {
     const res = await fetch(url, {
       method: 'GET',
-      headers: { Accept: 'application/json', 'User-Agent': `franklin/${VERSION}` },
+      headers: { ...gatewayHeaders(), Accept: 'application/json', 'User-Agent': `franklin/${VERSION}` },
       signal: controller.signal,
     });
     if (!res.ok) {
@@ -244,7 +245,7 @@ async function gatewayPost<T>(
   timeoutMs: number,
   ctx: ExecutionScope,
 ): Promise<T> {
-  const apiUrl = API_URLS[loadChain()];
+  const apiUrl = gatewayBase();
   const url = `${apiUrl}${ZEROX_GATEWAY_PATH}/${pathSuffix}`;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -254,6 +255,7 @@ async function gatewayPost<T>(
     const res = await fetch(url, {
       method: 'POST',
       headers: {
+        ...gatewayHeaders(),
         Accept: 'application/json',
         'Content-Type': 'application/json',
         'User-Agent': `franklin/${VERSION}`,

--- a/src/trading/providers/blockrun/client.ts
+++ b/src/trading/providers/blockrun/client.ts
@@ -16,6 +16,7 @@
 
 import type { ProviderError } from '../standard-models.js';
 import { USER_AGENT, loadChain } from '../../../config.js';
+import { gatewayHeaders, resolvePayMode } from '../../../payments/auth-mode.js';
 import { recordFetch } from '../telemetry.js';
 import {
   getOrCreateWallet,
@@ -30,10 +31,20 @@ import {
 
 const TIMEOUT_MS = 10_000;
 
-function baseUrl(): string {
-  // `loadChain()` dispatches on env / ~/.blockrun/payment-chain. We match it
-  // every call so mid-session chain switches take effect without restart.
-  return loadChain() === 'solana' ? 'https://sol.blockrun.ai' : 'https://blockrun.ai';
+/**
+ * Absolute URL for a gateway path. Callers pass `/api/v1/...` because that is
+ * the shape the x402 hosts serve; the API-key host serves the same routes at
+ * `/v1/...`, so the `/api` segment is stripped in key mode.
+ *
+ * `loadChain()` dispatches on env / ~/.blockrun/payment-chain and is read every
+ * call so mid-session chain switches take effect without a restart. In key mode
+ * the chain is irrelevant — the credit balance is chainless.
+ */
+function gatewayUrl(path: string): string {
+  const mode = resolvePayMode();
+  if (mode.kind === 'key') return mode.apiBase + path.replace(/^\/api/, '');
+  const origin = loadChain() === 'solana' ? 'https://sol.blockrun.ai' : 'https://blockrun.ai';
+  return origin + path;
 }
 
 interface CacheEntry<T> {
@@ -67,11 +78,11 @@ export async function blockrunGet(
 ): Promise<unknown | ProviderError> {
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
-  const url = `${baseUrl()}${path}`;
+  const url = gatewayUrl(path);
   const startedAt = Date.now();
   try {
     const res = await fetch(url, {
-      headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' },
+      headers: { ...gatewayHeaders(), 'User-Agent': USER_AGENT, Accept: 'application/json' },
       signal: ctrl.signal,
     });
     const latencyMs = Date.now() - startedAt;
@@ -213,10 +224,11 @@ export async function blockrunGetPaid(
 ): Promise<unknown | ProviderError> {
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
-  const url = `${baseUrl()}${path}`;
+  const url = gatewayUrl(path);
   const chain = loadChain();
   const startedAt = Date.now();
   const headers: Record<string, string> = {
+    ...gatewayHeaders(),
     'User-Agent': USER_AGENT,
     Accept: 'application/json',
   };

--- a/test/api-key.local.mjs
+++ b/test/api-key.local.mjs
@@ -1,0 +1,301 @@
+/**
+ * API-key payment mode — resolution, isolation from wallet mode, and the
+ * local pricing that replaces the x402 charge the key gateway never reports.
+ *
+ * HOME is redirected to a temp dir BEFORE any import, because config.ts
+ * resolves BLOCKRUN_DIR from os.homedir() at module load. Without this the
+ * suite would read and write the developer's real ~/.blockrun.
+ */
+
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const TEST_HOME = mkdtempSync(join(tmpdir(), 'franklin-apikey-'));
+process.env.HOME = TEST_HOME;
+delete process.env.BLOCKRUN_API_KEY;
+delete process.env.RUNCODE_CHAIN;
+process.env.FRANKLIN_NO_AUDIT = '1';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const auth = await import('../dist/payments/auth-mode.js');
+const { API_URLS, KEY_API_URL, BLOCKRUN_DIR, saveChain } = await import('../dist/config.js');
+const { redactSecrets } = await import('../dist/agent/secret-redact.js');
+const catalog = await import('../dist/payments/price-catalog.js');
+
+const VALID_KEY = 'brk_live_H4OzmQQDX09FElTg06Gv3Wh7i6C5jIozzVH0QBW5';
+const KEY_FILE = join(BLOCKRUN_DIR, 'api-key');
+
+function clean() {
+  delete process.env.BLOCKRUN_API_KEY;
+  rmSync(KEY_FILE, { force: true });
+  auth.resetPayModeCache();
+}
+
+function writeKeyFile(key) {
+  mkdirSync(BLOCKRUN_DIR, { recursive: true });
+  writeFileSync(KEY_FILE, key + '\n');
+  auth.resetPayModeCache();
+}
+
+// ─── Backward compatibility: no key means nothing changes ───────────────
+//
+// This is the guarantee the whole feature rests on. If it ever fails, every
+// existing wallet user's traffic has silently moved hosts.
+
+test('no key configured — wallet mode resolves to today exact host, per chain', () => {
+  clean();
+
+  saveChain('solana');
+  auth.resetPayModeCache();
+  let mode = auth.resolvePayMode();
+  assert.equal(mode.kind, 'wallet');
+  assert.equal(mode.apiBase, API_URLS.solana);
+  assert.equal(auth.gatewayBase(), 'https://sol.blockrun.ai/api');
+
+  saveChain('base');
+  auth.resetPayModeCache();
+  mode = auth.resolvePayMode();
+  assert.equal(mode.kind, 'wallet');
+  assert.equal(mode.apiBase, API_URLS.base);
+  assert.equal(auth.gatewayBase(), 'https://blockrun.ai/api');
+});
+
+test('no key configured — gateway headers carry no Authorization', () => {
+  clean();
+  const headers = auth.gatewayHeaders();
+  assert.equal('Authorization' in headers, false);
+  assert.ok(headers['User-Agent'], 'User-Agent is still set');
+});
+
+test('isKeyMode is false with no key', () => {
+  clean();
+  assert.equal(auth.isKeyMode(), false);
+});
+
+// ─── Key mode ───────────────────────────────────────────────────────────
+
+test('key on disk switches host to the key gateway and drops /api', () => {
+  clean();
+  writeKeyFile(VALID_KEY);
+
+  const mode = auth.resolvePayMode();
+  assert.equal(mode.kind, 'key');
+  assert.equal(mode.apiBase, KEY_API_URL);
+  assert.equal(auth.gatewayBase(), 'https://api.blockrun.ai');
+  // The key host 404s `wrong_host` on /api/v1/... — the base must not carry it.
+  assert.equal(auth.gatewayBase().endsWith('/api'), false);
+  assert.equal(auth.gatewayHeaders().Authorization, `Bearer ${VALID_KEY}`);
+  clean();
+});
+
+test('BLOCKRUN_API_KEY takes precedence over the key file', () => {
+  clean();
+  writeKeyFile('brk_live_fromdiskAAAAAAAAAAAAAAAAAAAAAAAA');
+  process.env.BLOCKRUN_API_KEY = VALID_KEY;
+  auth.resetPayModeCache();
+
+  assert.equal(auth.loadApiKey(), VALID_KEY);
+  assert.equal(auth.gatewayHeaders().Authorization, `Bearer ${VALID_KEY}`);
+  clean();
+});
+
+test('useWalletMode overrides a configured key', () => {
+  clean();
+  process.env.BLOCKRUN_API_KEY = VALID_KEY;
+  auth.resetPayModeCache();
+  assert.equal(auth.isKeyMode(), true);
+
+  auth.useWalletMode();
+  assert.equal(auth.isKeyMode(), false);
+  assert.equal('Authorization' in auth.gatewayHeaders(), false);
+  clean();
+});
+
+test('invalidateKey demotes the process to wallet mode', () => {
+  clean();
+  process.env.BLOCKRUN_API_KEY = VALID_KEY;
+  auth.resetPayModeCache();
+  assert.equal(auth.isKeyMode(), true);
+
+  auth.invalidateKey();
+  assert.equal(auth.isKeyMode(), false, 'a rejected key must not be retried all session');
+  clean();
+});
+
+test('a malformed key is ignored rather than sent to the gateway', () => {
+  clean();
+  // Truncated paste — sending this would produce a confusing 401 on the first
+  // paid call instead of an obvious "that is not a key" at configure time.
+  process.env.BLOCKRUN_API_KEY = 'brk_live_short';
+  auth.resetPayModeCache();
+  assert.equal(auth.isKeyMode(), false);
+  clean();
+});
+
+test('isApiKeyShaped accepts live and test keys, rejects other prefixes', () => {
+  assert.equal(auth.isApiKeyShaped(VALID_KEY), true);
+  assert.equal(auth.isApiKeyShaped('brk_test_' + 'a'.repeat(24)), true);
+  assert.equal(auth.isApiKeyShaped('sk-proj-' + 'a'.repeat(40)), false);
+  assert.equal(auth.isApiKeyShaped('brk_live_tooshort'), false);
+  assert.equal(auth.isApiKeyShaped(''), false);
+});
+
+test('maskApiKey never reveals the secret tail beyond four characters', () => {
+  const masked = auth.maskApiKey(VALID_KEY);
+  assert.ok(masked.startsWith('brk_live_'));
+  assert.equal(masked.includes(VALID_KEY), false);
+  assert.ok(masked.endsWith(VALID_KEY.slice(-4)));
+});
+
+// ─── Fallback classification ────────────────────────────────────────────
+
+test('only a bad key or an unserved path triggers a wallet fallback', () => {
+  assert.equal(auth.classifyKeyFailure(401, '{"code":"invalid_api_key"}'), 'invalid-key');
+  assert.equal(
+    auth.classifyKeyFailure(404, '{"code":"unsupported_endpoint"}'),
+    'unsupported-endpoint'
+  );
+  // A malformed request must NOT be retried on the wallet — that would spend
+  // real USDC on a call that was always going to fail.
+  assert.equal(auth.classifyKeyFailure(400, '{"error":"Invalid request body"}'), null);
+  assert.equal(auth.classifyKeyFailure(402, '{"error":"Payment Required"}'), null);
+  assert.equal(auth.classifyKeyFailure(500, 'boom'), null);
+  assert.equal(auth.classifyKeyFailure(404, '{"error":"Not Found"}'), null);
+});
+
+test('toWalletUrl moves a key-host URL onto the chain host, restoring /api', () => {
+  assert.equal(
+    auth.toWalletUrl('https://api.blockrun.ai/v1/exa/search', 'solana'),
+    'https://sol.blockrun.ai/api/v1/exa/search'
+  );
+  assert.equal(
+    auth.toWalletUrl('https://api.blockrun.ai/v1/chat/completions', 'base'),
+    'https://blockrun.ai/api/v1/chat/completions'
+  );
+  // Already a wallet URL — left alone.
+  assert.equal(
+    auth.toWalletUrl('https://blockrun.ai/api/v1/models', 'base'),
+    'https://blockrun.ai/api/v1/models'
+  );
+});
+
+
+// ─── Forwarded-request auth (the payment proxy) ─────────────────────────
+
+test('applyGatewayAuth replaces a client Authorization header, whatever its case', () => {
+  clean();
+  process.env.BLOCKRUN_API_KEY = VALID_KEY;
+  auth.resetPayModeCache();
+
+  // Node lowercases inbound header names. Before this was case-insensitive the
+  // proxy sent BOTH `authorization` and `Authorization`, the gateway read the
+  // client's, and every proxied call 401'd.
+  const headers = {
+    'content-type': 'application/json',
+    authorization: 'Bearer sk-ant-client-key',
+    'X-Franklin-Version': '1',
+  };
+  auth.applyGatewayAuth(headers);
+
+  const authKeys = Object.keys(headers).filter((k) => k.toLowerCase() === 'authorization');
+  assert.equal(authKeys.length, 1, 'exactly one Authorization header may survive');
+  assert.equal(headers[authKeys[0]], `Bearer ${VALID_KEY}`);
+  assert.equal(headers['content-type'], 'application/json', 'other headers are untouched');
+  clean();
+});
+
+test('applyGatewayAuth leaves a client Authorization alone in wallet mode', () => {
+  clean();
+  // Wallet mode contributes no credential — payment rides on the 402 retry —
+  // so stripping the client's header here would break plain pass-through.
+  const headers = { authorization: 'Bearer sk-ant-client-key' };
+  auth.applyGatewayAuth(headers);
+  assert.equal(headers.authorization, 'Bearer sk-ant-client-key');
+});
+
+// ─── Secret redaction ───────────────────────────────────────────────────
+
+test('a BlockRun API key is redacted from text', () => {
+  const { redactedText, matches } = redactSecrets(`my key is ${VALID_KEY} ok`);
+  assert.equal(redactedText.includes(VALID_KEY), false, 'the key must not survive redaction');
+  assert.ok(matches.some((m) => m.label === 'blockrun_api_key'));
+});
+
+test('redaction does not fire on ordinary text that merely starts with brk', () => {
+  const { matches } = redactSecrets('brk_live_ is a prefix, and brkfast is a word');
+  assert.equal(matches.some((m) => m.label === 'blockrun_api_key'), false);
+});
+
+// ─── Price catalog ──────────────────────────────────────────────────────
+
+test('priceForPath matches with or without the /api prefix and a query string', () => {
+  catalog.__resetPriceCatalog();
+  const withApi = catalog.priceForPath('/api/v1/surf/market/ranking');
+  const withoutApi = catalog.priceForPath('/v1/surf/market/ranking');
+  const withQuery = catalog.priceForPath('/v1/surf/market/ranking?symbol=BTC');
+  assert.equal(withApi, withoutApi);
+  assert.equal(withApi, withQuery);
+  assert.ok(withApi > 0, 'surf is a paid endpoint');
+});
+
+test('priceForPath accepts a full gateway URL from either host', () => {
+  catalog.__resetPriceCatalog();
+  const viaKeyHost = catalog.priceForPath('https://api.blockrun.ai/v1/rpc/base');
+  const viaWalletHost = catalog.priceForPath('https://blockrun.ai/api/v1/rpc/base');
+  assert.equal(viaKeyHost, viaWalletHost);
+  assert.ok(viaKeyHost > 0);
+});
+
+test('a more specific pattern beats a wildcard', () => {
+  catalog.__primePriceCatalog([
+    { endpoint: '/api/v1/modal/*', usd: 0.002 },
+    { endpoint: '/api/v1/modal/sandbox/create', usd: 0.011 },
+  ]);
+  assert.equal(catalog.priceForPath('/v1/modal/sandbox/create'), 0.011);
+  assert.equal(catalog.priceForPath('/v1/modal/sandbox/exec'), 0.002);
+  catalog.__resetPriceCatalog();
+});
+
+test('free endpoints price at zero, unknown endpoints price as null', () => {
+  catalog.__resetPriceCatalog();
+  assert.equal(catalog.priceForPath('/v1/models'), 0);
+  assert.equal(catalog.priceForPath('/v1/crypto/price/BTC'), 0);
+  // Chat is model-priced; gateway-models.ts owns it, so the catalog declines.
+  assert.equal(catalog.priceForPath('/v1/chat/completions'), null);
+});
+
+test('resolveCharge prefers a settled amount, then a reported one, then the catalog', () => {
+  catalog.__resetPriceCatalog();
+
+  const settled = catalog.resolveCharge({
+    apiPath: '/v1/surf/market/ranking', settledUsd: 0.0085, reportedUsd: 0.02,
+  });
+  assert.equal(settled.usd, 0.0085);
+  assert.equal(settled.estimated, false, 'a settled x402 amount is exact');
+
+  const reported = catalog.resolveCharge({
+    apiPath: '/v1/exa/search', reportedUsd: 0.007,
+  });
+  assert.equal(reported.usd, 0.007);
+  assert.equal(reported.estimated, false, 'a gateway-reported charge is exact');
+
+  const listed = catalog.resolveCharge({ apiPath: '/v1/surf/market/ranking' });
+  assert.ok(listed.usd > 0, 'key-mode calls must never record zero for paid work');
+  assert.equal(listed.estimated, true, 'a catalog price is an estimate');
+});
+
+test('resolveCharge falls back to a caller list price for an uncatalogued path', () => {
+  catalog.__primePriceCatalog([{ endpoint: '/api/v1/surf/*', usd: 0.0085 }]);
+  const charge = catalog.resolveCharge({ apiPath: '/v1/nonexistent/thing', fallbackUsd: 0.05 });
+  assert.equal(charge.usd, 0.05);
+  assert.equal(charge.estimated, true);
+  catalog.__resetPriceCatalog();
+});
+
+test('cleanup', () => {
+  clean();
+  rmSync(TEST_HOME, { recursive: true, force: true });
+});

--- a/test/api-key.local.mjs
+++ b/test/api-key.local.mjs
@@ -25,7 +25,9 @@ const { API_URLS, KEY_API_URL, BLOCKRUN_DIR, saveChain } = await import('../dist
 const { redactSecrets } = await import('../dist/agent/secret-redact.js');
 const catalog = await import('../dist/payments/price-catalog.js');
 
-const VALID_KEY = 'brk_live_H4OzmQQDX09FElTg06Gv3Wh7i6C5jIozzVH0QBW5';
+// Synthetic — shaped like a real key so the format checks are meaningful, but
+// not a credential. Never put a live key in a tracked file.
+const VALID_KEY = 'brk_live_0000TESTKEYNOTREAL0000000000000000000';
 const KEY_FILE = join(BLOCKRUN_DIR, 'api-key');
 
 function clean() {

--- a/test/local.mjs
+++ b/test/local.mjs
@@ -11697,8 +11697,15 @@ test('Exa tools record their settled USDC charge (was invisible to --max-spend)'
   }
   // The recordExaSpend helper is called for each endpoint (3 paths + 1 def = >=4).
   assert.ok((src.match(/recordExaSpend/g) || []).length >= 4, 'all three Exa paths must call recordExaSpend');
-  // Only record when a payment actually settled (avoid double-count on free path).
-  assert.match(src, /if \(!settled\)\s*return/, 'recordExaSpend must skip the un-paid path');
+  // The original guard here was `if (!settled) return` — skip anything that did
+  // not settle through x402. API-key mode broke that assumption: the gateway
+  // charges the prepaid balance and answers 200 without ever sending a 402, so
+  // `settled` is false for real spend and the early return recorded $0,
+  // silently disabling --max-spend. The guard is now on the resolved amount, so
+  // a genuinely free call is still skipped while a key-mode charge is counted.
+  assert.match(src, /if \(charge\.usd <= 0\)\s*\n?\s*return/, 'recordExaSpend must skip only genuinely zero charges');
+  assert.doesNotMatch(src, /if \(!settled\)\s*\n?\s*return/, 'an un-settled call is not necessarily an unpaid one');
+  assert.match(src, /resolveCharge/, 'un-settled calls must be priced from the catalog');
 });
 
 test('external-content tools frame attacker text as UNTRUSTED (searchx, voice join the convention)', async () => {


### PR DESCRIPTION
Adds a second way to fund Franklin: a prepaid BlockRun API key, next to the existing USDC wallet. Solana leads Base everywhere in the docs and CLI copy, and the README now says where to sign up and top up.

Design doc: `docs/plans/2026-09-05-api-key-auth-design.md` (probed facts, not assumptions).

## The two gateways share no auth

| | Wallet | API key |
| --- | --- | --- |
| Host | `sol.blockrun.ai/api` / `blockrun.ai/api` | `api.blockrun.ai` (no `/api`) |
| Auth | x402 `PAYMENT-SIGNATURE` | `Authorization: Bearer brk_...` |
| Settlement | On-chain, per call | Prepaid credit |

A bearer key on the x402 hosts is ignored and still 402s; `api.blockrun.ai` 401s with no x402 fallback. That isolation is what lets this ship without touching wallet users — with no key set, `resolvePayMode()` returns the same host and headers as before, asserted per chain by test rather than by inspection.

All 33 gateway paths Franklin calls were probed with a live key and route correctly. The four that return `unsupported_endpoint` are 404 on the x402 hosts too — dead references in `src/`, left for a separate cleanup.

## The real problem was accounting, not routing

The key gateway settles silently and **returns no charge amount**. Franklin derives its whole ledger from the 402 handshake: `paidUsd` is only assigned inside the 402 branch, and `exa.ts` returned early on `if (!settled)`. So every paid call in key mode would have recorded **$0**, silently disabling `--max-spend`, `PreSpend` hooks, and every budget in the product.

Paid calls are now priced from BlockRun's published rate card at `/.well-known/x402`, and each row is tagged exact vs estimated. `franklin stats` marks estimated totals with `~` and reports the estimated portion separately; `franklin balance` refuses to invent a credit balance it cannot read and links the dashboard instead.

Known bias: that rate card is the x402 one, which carries a 5% margin and $0.001/call that key mode does not charge. Franklin therefore reads a few percent high. That is the safe direction for a spend ceiling and it is disclosed in the README, not hidden. A `x-blockrun-charged-usd` response header on the gateway would remove the estimate entirely — see §7 of the design doc.

## A bug found by live-testing the proxy

Node lowercases the proxied client's `authorization`; `gatewayHeaders()` returns the canonical `Authorization`. A plain object held both, `fetch` sent two Authorization headers, and the gateway read the client's — every proxied call 401'd. `applyGatewayAuth()` strips every case variant first. Regression test included.

## Also

`brk_` had no entry in the secret redactor, so a key could reach transcripts and `franklin logs`. Added.

## Verification

- 711 CLI tests + the desktop suite pass (23 new tests).
- Live against the gateway with a real key: chat, Exa, Surf, and the payment proxy in key mode.
- Live in wallet mode: chat settles exactly as before ($0.004046 recorded from the x402 amount).
- Surf on the Solana wallet path fails with `verification_failed` — **verified to reproduce identically on `main`**, so it predates this branch. Flagged in §11, not fixed here.

## Not done

An editable API-key field in the desktop panel. The desktop RPC is read-only for credentials by design and adding a secret write path is a bigger security decision than this change should make alone. The panel does now state when spend is coming from a key instead of presenting the USDC balance as the budget. Keys are set with `franklin login`.

## Still needs a human

Dashboard reconciliation. The gateway exposes no key-scoped balance or usage endpoint, so Franklin's tally cannot be automatically checked against `user.blockrun.ai`. §6 has the manual procedure and the expected drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LZQ4mfQVs2JJhC2ALfyGjt