### PR TITLE
fix: require explicit wallet selection after account errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Franklin Agent
 
-Open-source AI agent with a wallet. <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models. Pay per use with USDC via x402.
+Open-source AI agent with a wallet. <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models. Pay per use with BlockRun API account credit or USDC wallets via x402.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ VS Code → Extensions  (Cmd+Shift+X / Ctrl+Shift+X)
         → click the Franklin icon in the Activity Bar
 ```
 
-Free models work immediately. Paid models, image gen, and video gen activate the moment your wallet has USDC. The CLI and the extension share the same `~/.blockrun/` config and session history, so jumping between terminal and VS Code is seamless.
+Free models work immediately. Paid models, image gen, and video gen use your selected payment method: funded API account credit or a USDC wallet. The CLI and the extension share the same `~/.blockrun/` config and session history, so jumping between terminal and VS Code is seamless.
 
 ### Franklin Desktop (Beta)
 
@@ -205,8 +205,10 @@ franklin balance --wallet         # show the wallet balance, not the key status
 ```
 
 If the key is rejected, or a tool needs an endpoint the key gateway does not serve,
-Franklin falls back to the wallet for that call and tells you. It never falls back on a
-malformed request — a bad call is never retried with your USDC.
+Franklin returns that API error without charging a wallet. Correct the key or explicitly
+retry with `--wallet`. An empty or malformed configured key is an error; remove it to
+return to the wallet default. `franklin logout` removes the saved key; if
+`BLOCKRUN_API_KEY` is exported, unset it too.
 
 ### One honest caveat about spend tracking
 
@@ -329,7 +331,7 @@ Every trade journals itself: thesis on open, P&L on close, written to a **wallet
   Saved: generated-logo-1713052800.png (1024x1024)
 ```
 
-Generates images via DALL-E / GPT Image directly from the CLI. Paid from your wallet — no OpenAI API key needed.
+Generates images via DALL-E / GPT Image directly from the CLI. Paid from your selected BlockRun API account or wallet — no OpenAI API key needed.
 
 ### 📱 Remote control via Telegram
 

--- a/src/agent/llm.ts
+++ b/src/agent/llm.ts
@@ -811,7 +811,9 @@ export class ModelClient {
       );
 
       // Handle x402 payment
-      if (response.status === 402) {
+      // Account 402 is a credit refusal. Only a request that started on
+      // the wallet rail may initiate a signing handshake.
+      if (response.status === 402 && !headers.Authorization) {
         if (this.debug) console.error('[franklin] Payment required — signing...');
         const signedPayment = await this.signPayment(response, request.model);
         if (!signedPayment) {

--- a/src/payments/auth-mode.ts
+++ b/src/payments/auth-mode.ts
@@ -66,15 +66,9 @@ export function useWalletMode(): void {
   cached = null;
 }
 
-/**
- * Demote to wallet mode after the gateway rejected the key (401). Called once
- * per process — a key that does not authenticate will not authenticate on the
- * next call either, and retrying it on every request would double the latency
- * of an entire session.
- */
+/** Refresh a rejected credential without changing the user's payment method. */
 export function invalidateKey(): void {
-  if (cached?.kind === 'key') cached = null;
-  forceWallet = true;
+  cached = null;
 }
 
 /** Test seam — drop the memoised mode so env/file changes are re-read. */
@@ -86,16 +80,17 @@ export function resetPayModeCache(): void {
 function readKeyFile(): string | null {
   try {
     const raw = fs.readFileSync(API_KEY_FILE, 'utf-8').trim();
-    return raw || null;
-  } catch {
-    return null; // no key on disk — wallet mode
+    return raw;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw new Error('Cannot read the saved API key. Fix its permissions or explicitly use --wallet.');
   }
 }
 
 /** The key Franklin would use, from env first then disk. Null when unset. */
 export function loadApiKey(): string | null {
   const fromEnv = process.env.BLOCKRUN_API_KEY?.trim();
-  if (fromEnv) return fromEnv;
+  if (fromEnv !== undefined) return fromEnv;
   return readKeyFile();
 }
 
@@ -120,7 +115,7 @@ export function clearApiKey(): boolean {
  * Resolve the active payment mode. Memoised per process — the resolution reads
  * the filesystem and is hit on every gateway call.
  *
- * Precedence: `--wallet` / a rejected key > BLOCKRUN_API_KEY > ~/.blockrun/api-key
+ * Precedence: `--wallet` > BLOCKRUN_API_KEY > ~/.blockrun/api-key
  * > wallet on the active chain.
  */
 export function resolvePayMode(): PayMode {
@@ -128,7 +123,10 @@ export function resolvePayMode(): PayMode {
 
   if (!forceWallet) {
     const key = loadApiKey();
-    if (key && isApiKeyShaped(key)) {
+    if (key !== null) {
+      if (!isApiKeyShaped(key)) {
+        throw new Error('Invalid API key in BLOCKRUN_API_KEY or the saved key file. Correct it, remove it, or explicitly use --wallet.');
+      }
       cached = { kind: 'key', apiBase: KEY_API_URL, key };
       return cached;
     }
@@ -152,7 +150,7 @@ export function gatewayBase(): string {
   return resolvePayMode().apiBase;
 }
 
-/** The x402 base to retry against when a key-mode call has to fall back. */
+/** The x402 base for an explicitly selected wallet chain. */
 export function walletBase(chain: Chain = loadChain()): string {
   return API_URLS[chain];
 }
@@ -195,16 +193,7 @@ export function applyGatewayAuth(
   return headers;
 }
 
-/**
- * Classify a key-mode failure so callers know whether falling back to the
- * wallet is safe.
- *
- * Only two statuses are worth retrying elsewhere. A 401 means the key itself
- * is bad, so the whole process demotes. A 404 `unsupported_endpoint` means
- * this one path is not served on the key host, so only that call falls back.
- * Everything else — 400, 402, 5xx — surfaces as-is, so a malformed request
- * never silently drains wallet USDC on a second attempt.
- */
+/** Classify account errors for display; neither error authorizes wallet billing. */
 export type KeyFailure = 'invalid-key' | 'unsupported-endpoint' | null;
 
 export function classifyKeyFailure(status: number, body: string): KeyFailure {
@@ -214,7 +203,7 @@ export function classifyKeyFailure(status: number, body: string): KeyFailure {
 }
 
 /**
- * Rewrite a key-host URL onto the wallet host for a fallback retry. The two
+ * Rewrite a key-host URL after the user explicitly selects wallet mode. The two
  * differ by the `/api` segment the wallet hosts carry, so this swaps the
  * origin and re-adds it rather than a plain string replace.
  */

--- a/src/payments/post-with-payment.ts
+++ b/src/payments/post-with-payment.ts
@@ -24,11 +24,8 @@ import {
 } from '@blockrun/llm';
 import { loadChain, USER_AGENT, type Chain } from '../config.js';
 import {
-  classifyKeyFailure,
   gatewayHeaders,
-  invalidateKey,
   resolvePayMode,
-  toWalletUrl,
 } from './auth-mode.js';
 
 async function extractPaymentReq(response: Response): Promise<string | null> {
@@ -138,18 +135,11 @@ export async function postWithPayment(
         body: payload,
       });
       const keyRaw = await keyResponse.text().catch(() => '');
-      const failure = classifyKeyFailure(keyResponse.status, keyRaw);
-
-      // Only a bad key or a path the key host does not serve is worth retrying
-      // on the wallet. Anything else (400, 402, 5xx) is returned as-is so a
-      // malformed request never silently spends wallet USDC on a second try.
-      if (!failure) {
-        let parsedKey: Record<string, unknown> = {};
-        try { parsedKey = keyRaw ? JSON.parse(keyRaw) : {}; } catch { /* leave as {} */ }
-        return { ok: keyResponse.ok, status: keyResponse.status, body: parsedKey, raw: keyRaw, settled: false };
-      }
-      if (failure === 'invalid-key') invalidateKey();
-      endpoint = toWalletUrl(endpoint, chain);
+      // An account failure is never permission to spend from a wallet.
+      // The user can explicitly select --wallet and retry the command.
+      let parsedKey: Record<string, unknown> = {};
+      try { parsedKey = keyRaw ? JSON.parse(keyRaw) : {}; } catch { /* leave as {} */ }
+      return { ok: keyResponse.ok, status: keyResponse.status, body: parsedKey, raw: keyRaw, settled: false };
     }
 
     const headers: Record<string, string> = {

--- a/test/api-key.local.mjs
+++ b/test/api-key.local.mjs
@@ -42,6 +42,31 @@ function writeKeyFile(key) {
   auth.resetPayModeCache();
 }
 
+test('Messages API credit refusal never invokes wallet signing', async () => {
+  clean();
+  process.env.BLOCKRUN_API_KEY = VALID_KEY;
+  const { ModelClient } = await import('../dist/agent/llm.js');
+  const client = new ModelClient({ apiUrl: KEY_API_URL, chain: 'solana' });
+  const nativeFetch = globalThis.fetch;
+  let signed = false;
+  let requests = 0;
+  client.signPayment = async () => { signed = true; return null; };
+  globalThis.fetch = async () => {
+    requests++;
+    return Response.json({ error: { message: 'Account credits exhausted' } }, { status: 402 });
+  };
+  try {
+    const events = [];
+    for await (const event of client.streamCompletion({ model: 'anthropic/claude-haiku-4.5', messages: [{ role: 'user', content: 'Hello' }], max_tokens: 8 })) events.push(event);
+    assert.equal(signed, false);
+    assert.equal(requests, 1);
+    assert.match(events.find(event => event.kind === 'error')?.payload.message ?? '', /credits exhausted/);
+  } finally {
+    globalThis.fetch = nativeFetch;
+    clean();
+  }
+});
+
 // ─── Backward compatibility: no key means nothing changes ───────────────
 //
 // This is the guarantee the whole feature rests on. If it ever fails, every

--- a/test/api-key.local.mjs
+++ b/test/api-key.local.mjs
@@ -116,24 +116,24 @@ test('useWalletMode overrides a configured key', () => {
   clean();
 });
 
-test('invalidateKey demotes the process to wallet mode', () => {
+test('invalidateKey refreshes credentials without changing the payment method', () => {
   clean();
   process.env.BLOCKRUN_API_KEY = VALID_KEY;
   auth.resetPayModeCache();
   assert.equal(auth.isKeyMode(), true);
 
   auth.invalidateKey();
-  assert.equal(auth.isKeyMode(), false, 'a rejected key must not be retried all session');
+  assert.equal(auth.isKeyMode(), true, 'only an explicit wallet selection changes payment method');
   clean();
 });
 
-test('a malformed key is ignored rather than sent to the gateway', () => {
+test('a malformed configured key fails before any wallet fallback', () => {
   clean();
   // Truncated paste — sending this would produce a confusing 401 on the first
   // paid call instead of an obvious "that is not a key" at configure time.
   process.env.BLOCKRUN_API_KEY = 'brk_live_short';
   auth.resetPayModeCache();
-  assert.equal(auth.isKeyMode(), false);
+  assert.throws(() => auth.isKeyMode(), /BLOCKRUN_API_KEY/);
   clean();
 });
 
@@ -154,7 +154,7 @@ test('maskApiKey never reveals the secret tail beyond four characters', () => {
 
 // ─── Fallback classification ────────────────────────────────────────────
 
-test('only a bad key or an unserved path triggers a wallet fallback', () => {
+test('classifies account failures without choosing a payment method', () => {
   assert.equal(auth.classifyKeyFailure(401, '{"code":"invalid_api_key"}'), 'invalid-key');
   assert.equal(
     auth.classifyKeyFailure(404, '{"code":"unsupported_endpoint"}'),
@@ -300,4 +300,62 @@ test('resolveCharge falls back to a caller list price for an uncatalogued path',
 test('cleanup', () => {
   clean();
   rmSync(TEST_HOME, { recursive: true, force: true });
+});
+
+for (const status of [401, 402, 404, 429, 500]) {
+  test(`API ${status} preserves the selected account and never retries with a wallet`, async () => {
+    clean();
+    process.env.BLOCKRUN_API_KEY = VALID_KEY;
+    const calls = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init) => {
+      calls.push({ url, headers: new Headers(init.headers) });
+      return new Response(JSON.stringify({ code: status === 404 ? 'unsupported_endpoint' : 'rejected' }), { status });
+    };
+    try {
+      const { postWithPayment } = await import('../dist/payments/post-with-payment.js');
+      const result = await postWithPayment(`${KEY_API_URL}/v1/exa/search`, { query: 'test' }, 'test');
+      assert.equal(calls.length, 1, 'account errors must never trigger a wallet request');
+      assert.equal(result.status, status);
+      assert.equal(result.settled, false);
+      assert.equal(calls[0].headers.get('authorization'), `Bearer ${VALID_KEY}`);
+      assert.equal(auth.resolvePayMode().kind, 'key');
+    } finally {
+      globalThis.fetch = originalFetch;
+      clean();
+    }
+  });
+}
+
+for (const source of ['env', 'file']) {
+  for (const value of ['', '   ', 'not-a-key']) {
+    test(`invalid ${source} configuration cannot silently select a wallet (${JSON.stringify(value)})`, () => {
+      clean();
+      try {
+        if (source === 'env') process.env.BLOCKRUN_API_KEY = value;
+        else writeKeyFile(value);
+        assert.throws(() => auth.resolvePayMode(), /API.key|BLOCKRUN_API_KEY/i);
+        auth.useWalletMode();
+        assert.equal(auth.resolvePayMode().kind, 'wallet', 'explicit --wallet still works');
+      } finally { clean(); }
+    });
+  }
+}
+
+test('saving, rotating and removing a key refreshes request credentials across both wallet chains', () => {
+  clean();
+  try {
+    const secondKey = 'brk_test_' + 'b'.repeat(24);
+    auth.saveApiKey(VALID_KEY);
+    assert.equal(auth.gatewayHeaders().Authorization, `Bearer ${VALID_KEY}`);
+    auth.saveApiKey(secondKey);
+    assert.equal(auth.gatewayHeaders().Authorization, `Bearer ${secondKey}`);
+    assert.equal(auth.clearApiKey(), true);
+    for (const chain of ['solana', 'base']) {
+      saveChain(chain);
+      auth.resetPayModeCache();
+      assert.equal(auth.gatewayBase(), API_URLS[chain]);
+      assert.equal('Authorization' in auth.gatewayHeaders(), false);
+    }
+  } finally { clean(); }
 });

--- a/test/reservation.local.mjs
+++ b/test/reservation.local.mjs
@@ -42,7 +42,10 @@ test('markAmbiguous is idempotent and release-then-mark does not resurrect a hol
   assert.equal(walletReservation.snapshot().totalUsd, 0.06);
 });
 
-test('ambiguous holds self-heal only on a real balance read that started after the window', async () => {
+test('ambiguous holds self-heal only on a real balance read that started after the window', async (t) => {
+  // This test checks a 1 ms boundary; wall-clock scheduling must not move it.
+  const now = Date.now();
+  t.mock.method(Date, 'now', () => now);
   let fetches = 0;
   walletReservation._resetForTests(async () => { fetches++; return 0.10; });
   const a = await walletReservation.hold(0.06);


### PR DESCRIPTION
An API 401 or unsupported-endpoint 404 silently replayed the request against a wallet gateway; a 401 also switched the rest of the process to wallet billing. This follow-up to #157 returns account errors without changing payment methods. Users can explicitly retry with --wallet.

Invalid, empty or unreadable configured keys now stop with an actionable error instead of selecting a wallet or another saved account. Key saving, rotation and logout refresh the active credential. README and agent instructions describe API registration/top-ups and explicit switching. The wallet reservation boundary test now uses a fixed clock instead of relying on a 1 ms scheduling window.

Validation: build and all 724 local tests pass. New tests cover 401/402/404/429/500 without wallet replay, invalid env/file configuration, explicit --wallet and key rotation/logout across Solana and Base. The fallback tests failed before this patch. Production paid Anthropic Messages SSE and Surf calls now pass against api.blockrun.ai, with account credit snapshots and matching portal receipts. Follow-up coverage found the separate Messages 402 path still invoked wallet signing; preserve the gateway credit error and never sign a key-authenticated request. Its regression test failed before the fix. No real wallet transfers were executed.

Based on current main, rather than the older open #156. Automatic account-to-wallet fallback is deliberately removed because it changes who pays.
