### PR TITLE
feat(pricing): book the gateway's stated charge, and stop trusting upstream cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ interchangeable. Everything else about the agent is identical.
 | Settlement | On-chain, per call, via [x402](https://x402.org) | Against a prepaid balance |
 | Gateway | `sol.blockrun.ai` / `blockrun.ai` | `api.blockrun.ai` |
 | Where the money lives | A wallet only you hold the key to | Your BlockRun account |
-| Spend visibility | `franklin stats` — exact settled amounts | [Dashboard](https://user.blockrun.ai/dashboard) — see the note below |
+| Spend visibility | `franklin stats` — exact settled amounts | `franklin balance` + [dashboard](https://user.blockrun.ai/dashboard); exact except chat |
 
 **The wallet is still Franklin's identity.** Memory, the trading journal and goals are
 keyed to it, and the wallet route is the one that needs nothing from us — no signup, no
@@ -208,23 +208,33 @@ If the key is rejected, or a tool needs an endpoint the key gateway does not ser
 Franklin falls back to the wallet for that call and tells you. It never falls back on a
 malformed request — a bad call is never retried with your USDC.
 
-### One honest caveat about spend tracking
+### Spend tracking, and the one thing that stays an estimate
 
 In wallet mode every charge is exact: the gateway states the price in the x402 handshake
 and Franklin records the amount that actually settled.
 
-In API-key mode the gateway settles silently against your balance and **returns no charge
-amount**. Franklin prices those calls locally from BlockRun's published x402 rate card, so
-`--max-spend`, `PreSpend` hooks and budgets all keep working — but the figures are
-estimates, and they lean high. The x402 rate card includes a 5% margin and a $0.001
-per-transaction fee that key mode does not charge (key mode bills provider list price;
-the fee is taken when you top up). Expect Franklin's local tally to read a few percent
-above what the dashboard shows.
+In API-key mode most calls now report what they cost. The gateway returns an
+`x-blockrun-cost-usd` header on the pre-priced service families — search, images, RPC,
+market data, phone, sandboxes — and Franklin records that figure exactly.
 
-Over-counting is the safe direction for a spend ceiling, and Franklin is explicit about
-it: `franklin stats` marks estimated totals with `~` and reports the estimated portion
-separately, and `franklin balance` will not invent a credit balance it cannot read. For
-the authoritative number, use the [dashboard](https://user.blockrun.ai/dashboard).
+**Chat is the exception, permanently.** Chat settles *after* the answer is on the wire, so
+a slow settlement never becomes a slow answer, which means the amount does not exist yet
+when the headers are written. Franklin reconstructs chat spend from token counts and the
+published rate, so chat rows are estimates. `franklin stats` marks estimated totals with
+`~` and reports the estimated portion separately, so you can always see which is which.
+
+`franklin balance` reads your real credit standing from the gateway:
+
+```
+Account:   acme (gated)
+Remaining: $41.9980 of $50.00 granted
+Spent:     $8.0020  (BlockRun, authoritative)
+Local:     ~$8.0431  (Franklin's own tally, all time, both pay modes — expected to differ)
+```
+
+The two numbers differ on purpose: Franklin's tally covers both pay modes and estimates
+chat, while BlockRun's is what you were actually billed. For the full per-call history,
+use the [dashboard](https://user.blockrun.ai/dashboard).
 
 ---
 

--- a/src/commands/balance.ts
+++ b/src/commands/balance.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { setupAgentWallet, setupAgentSolanaWallet } from '@blockrun/llm';
 import { loadChain, DASHBOARD_URL } from '../config.js';
-import { isKeyMode, loadApiKey, maskApiKey } from '../payments/auth-mode.js';
+import { fetchCreditBalance, isKeyMode, loadApiKey, maskApiKey } from '../payments/auth-mode.js';
 import { loadStats } from '../stats/tracker.js';
 
 export async function balanceCommand() {
@@ -16,21 +16,52 @@ export async function balanceCommand() {
     const key = loadApiKey();
     console.log(`Pay mode:  ${chalk.green('api-key')}`);
     console.log(`Key:       ${chalk.cyan(key ? maskApiKey(key) : 'unknown')}`);
+    const credit = await fetchCreditBalance();
+    if (credit) {
+      console.log(`Account:   ${chalk.dim(credit.accountId)} (${chalk.dim(credit.billingMode)})`);
+      // `ungated` means no ceiling, and remaining_usd is legitimately null.
+      // Coalescing that to 0 would tell a paying customer they are broke, so
+      // branch on the mode rather than on the number.
+      if (credit.remainingUsd !== null) {
+        const low = credit.remainingUsd < 1;
+        console.log(
+          `Remaining: ${(low ? chalk.yellow : chalk.green)('$' + credit.remainingUsd.toFixed(4))}` +
+          chalk.dim(` of $${credit.grantedUsd.toFixed(2)} granted`)
+        );
+      } else {
+        console.log(`Remaining: ${chalk.dim('no prepaid limit on this account')}`);
+      }
+      console.log(`Spent:     ${chalk.cyan('$' + credit.spentUsd.toFixed(4))}` + chalk.dim('  (BlockRun, authoritative)'));
+      if (credit.blocked) {
+        // An append-only code set — show the raw code when it is one we do not
+        // know rather than swallowing it.
+        const explain: Record<string, string> = {
+          ACCOUNT_SUSPENDED: 'this account is suspended',
+          CREDIT_LIMIT_REACHED: 'the credit limit has been reached',
+          BALANCE_EXHAUSTED: 'the prepaid balance is exhausted',
+        };
+        const reason = credit.blockedReason
+          ? explain[credit.blockedReason] ?? `blocked (${credit.blockedReason})`
+          : 'blocked';
+        console.log(chalk.red(`\nYour next paid call will be refused — ${reason}.`));
+        console.log(chalk.dim(`Top up at ${DASHBOARD_URL}/dashboard.`));
+      }
+    }
+
     try {
       const stats = loadStats();
       const spent = stats.totalCostUsd ?? 0;
       const est = stats.totalEstimatedCostUsd ?? 0;
       console.log(
-        `Spent:     ${chalk.yellow((est > 0 ? '~$' : '$') + spent.toFixed(4))}` +
-        chalk.dim('  (Franklin\'s local tally, all time)')
+        `Local:     ${chalk.dim((est > 0 ? '~$' : '$') + spent.toFixed(4))}` +
+        chalk.dim("  (Franklin's own tally, all time, both pay modes — expected to differ)")
       );
     } catch { /* stats are best-effort */ }
-    console.log(
-      chalk.dim(`\nCredit balance and full activity: ${DASHBOARD_URL}/dashboard`)
-    );
-    console.log(
-      chalk.dim('Franklin cannot read the credit balance — the gateway exposes no endpoint for it.')
-    );
+
+    if (!credit) {
+      console.log(chalk.dim(`\nCould not read the credit balance from the gateway.`));
+    }
+    console.log(chalk.dim(`\nFull activity: ${DASHBOARD_URL}/dashboard`));
     console.log(chalk.dim('To spend from a USDC wallet instead: franklin --wallet, or franklin logout.'));
     return;
   }

--- a/src/payments/auth-mode.ts
+++ b/src/payments/auth-mode.ts
@@ -168,6 +168,69 @@ export function gatewayHeaders(mode: PayMode = resolvePayMode()): Record<string,
 }
 
 /**
+ * A key's credit standing, from GET /v1/credits. The authoritative figure for
+ * display — the per-response `x-blockrun-credit-remaining-usd` header can
+ * understate under concurrency and is for warnings, not for showing a user.
+ */
+export interface CreditBalance {
+  accountId: string;
+  /**
+   * `ungated` accounts have NO ceiling, so `remainingUsd` is legitimately null.
+   * Never coalesce that to 0 — it would tell a paying customer they are broke.
+   * Branch on this field instead.
+   */
+  billingMode: string;
+  currency: string;
+  grantedUsd: number;
+  spentUsd: number;
+  remainingUsd: number | null;
+  blocked: boolean;
+  /**
+   * A stable CODE to map, not a string to show: ACCOUNT_SUSPENDED,
+   * CREDIT_LIMIT_REACHED, BALANCE_EXHAUSTED. Treated as append-only, so an
+   * unrecognised value must degrade gracefully rather than throw.
+   */
+  blockedReason: string | null;
+}
+
+/**
+ * Fetch the key's credit standing. Null when there is no key, the gateway is
+ * unreachable, or it answers with something unexpected — callers show what they
+ * do know rather than inventing a number.
+ *
+ * `blocked` describes what the gateway would do with the NEXT call, so it is
+ * safe to gate an autonomous run on.
+ */
+export async function fetchCreditBalance(timeoutMs = 15_000): Promise<CreditBalance | null> {
+  const key = loadApiKey();
+  if (!key) return null;
+  try {
+    const res = await fetch(`${KEY_API_URL}/v1/credits`, {
+      headers: { Authorization: `Bearer ${key}`, 'User-Agent': USER_AGENT },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!res.ok) return null;
+    const b = (await res.json()) as Record<string, unknown>;
+    const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
+    return {
+      accountId: typeof b.account_id === 'string' ? b.account_id : 'unknown',
+      billingMode: typeof b.billing_mode === 'string' ? b.billing_mode : 'unknown',
+      currency: typeof b.currency === 'string' ? b.currency : 'USD',
+      grantedUsd: num(b.granted_usd),
+      spentUsd: num(b.spent_usd),
+      // Explicitly preserve null — the whole point of this field.
+      remainingUsd: typeof b.remaining_usd === 'number' && Number.isFinite(b.remaining_usd)
+        ? b.remaining_usd
+        : null,
+      blocked: b.blocked === true,
+      blockedReason: typeof b.blocked_reason === 'string' ? b.blocked_reason : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Merge this mode's auth into a header bag that may already carry a client's
  * own credential, in place.
  *

--- a/src/payments/price-catalog.ts
+++ b/src/payments/price-catalog.ts
@@ -354,6 +354,61 @@ export function priceForPath(apiPath: string): number | null {
 }
 
 /**
+ * The exact amount BlockRun charged for this call, from
+ * `x-blockrun-cost-usd`, or null when the response does not state one.
+ *
+ * Live on the pre-priced service families (exa, surf, pm, phone, modal,
+ * speech, images, rpc, defillama). Deliberately and permanently ABSENT on
+ * chat, which settles after the answer is on the wire (`x-settlement-async`)
+ * — at header-writing time the amount does not exist yet, and waiting for it
+ * would mean holding the customer's response until the money lands. Chat is
+ * reconstructed from tokens x published rate instead.
+ *
+ * Absent means "no charge settled at response time", NOT "free" — reading it
+ * as $0 would zero out chat, the largest spend category. A charge that really
+ * did settle at zero is written explicitly as `0.000000`, so 0 is a value and
+ * missing is not.
+ *
+ * Empty, malformed and negative are all treated as absent. `Number('')` is 0
+ * in JS, which would book $0 against a billed call.
+ */
+export function chargeFromResponse(res: HeaderBag): number | null {
+  return usdHeader(res, 'x-blockrun-cost-usd');
+}
+
+/**
+ * Credit left on the account after this call, from
+ * `x-blockrun-credit-remaining-usd`. Absent on ungated accounts, which have no
+ * ceiling and so nothing to report — that is correct, not a failure.
+ *
+ * It can understate and never overstates: the figure is read inside the
+ * reservation transaction, already net of concurrent in-flight holds. That is
+ * the right error direction for a pre-run low-balance warning (warn early
+ * rather than fail to warn), and the wrong one for display — GET /v1/credits
+ * is the authority for a number shown to a user.
+ */
+export function remainingCreditFromResponse(res: HeaderBag): number | null {
+  return usdHeader(res, 'x-blockrun-credit-remaining-usd');
+}
+
+interface HeaderBag { headers: { get(name: string): string | null } }
+
+/**
+ * Shared parse for both money headers. 0 is a value; empty, malformed and
+ * negative are all absence. `Number('')` is 0 in JS, which would book $0
+ * against a billed call.
+ */
+function usdHeader(res: HeaderBag, name: string): number | null {
+  const raw = res.headers.get(name);
+  if (raw === null) return null;
+  const trimmed = raw.trim();
+  if (trimmed === '') return null;
+  const n = Number(trimmed);
+  if (!Number.isFinite(n) || n < 0) return null;
+  return n;
+}
+
+/**
  * The amount to record for a completed paid call.
  *
  * `settledUsd` is the exact figure from an x402 settlement and always wins.
@@ -368,16 +423,29 @@ export interface ResolvedCharge {
 
 export function resolveCharge(opts: {
   apiPath: string;
+  /** From `x-blockrun-cost-usd` — what BlockRun actually charged. Wins outright. */
+  chargedUsd?: number | null;
   settledUsd?: number;
   reportedUsd?: number;
   fallbackUsd?: number;
 }): ResolvedCharge {
-  const { apiPath, settledUsd, reportedUsd, fallbackUsd } = opts;
+  const { apiPath, chargedUsd, settledUsd, reportedUsd, fallbackUsd } = opts;
+  // The gateway stating its own charge beats every other source, including a
+  // settled x402 amount. 0 is a real answer here, so test for null, not truth.
+  if (typeof chargedUsd === 'number') {
+    return { usd: chargedUsd, estimated: false };
+  }
   if (typeof settledUsd === 'number' && settledUsd > 0) {
     return { usd: settledUsd, estimated: false };
   }
+  // An upstream provider's self-reported cost is NOT what BlockRun charged.
+  // Measured 2026-09-05: Exa reported costDollars $0.007 on a call BlockRun
+  // charged $0.010 for. Treating it as exact booked a wrong number with false
+  // confidence, which is worse than a hedged one — so it now ranks below the
+  // catalog price and is tagged estimated like any other guess.
   if (typeof reportedUsd === 'number' && reportedUsd > 0) {
-    return { usd: reportedUsd, estimated: false };
+    const listed = priceForPath(apiPath);
+    return { usd: listed !== null && listed > 0 ? listed : reportedUsd, estimated: true };
   }
   const listed = priceForPath(apiPath);
   if (listed !== null) return { usd: listed, estimated: true };

--- a/src/payments/price-catalog.ts
+++ b/src/payments/price-catalog.ts
@@ -26,6 +26,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { BLOCKRUN_DIR, USER_AGENT } from '../config.js';
 import { logger } from '../logger.js';
+import { GATEWAY_TRANSACTION_FEE_USD } from '../gateway-models.js';
 
 /**
  * Always the Base origin — because it is the only host serving the SHAPE this
@@ -351,6 +352,36 @@ export function priceForPath(apiPath: string): number | null {
     if (!best || score > best.score) best = { usd: entry.usd, score };
   }
   return best ? best.usd : null;
+}
+
+
+/**
+ * The base price for an endpoint — what the API-key rail charges — or null
+ * when the endpoint is not catalogued.
+ *
+ * There are two real prices per endpoint and one literal cannot serve both.
+ * The catalog and the 402 challenge both state the WALLET price, which is the
+ * base plus a settlement fee. The key rail charges the base and no fee, which
+ * is why it issues no 402 at all.
+ *
+ * Measured 2026-09-05 via x-blockrun-cost-usd against the unsigned 402:
+ *
+ *   endpoint    402 / catalog    key rail charges
+ *   surf        $0.0085          $0.0075
+ *   rpc         $0.0030          $0.0020
+ *   exa search  $0.0110          $0.0100
+ *   defillama   $0.0060          $0.0050
+ *
+ * Exactly one fee apart, every time. Quoting the 402 figure to a key-mode user
+ * overstates every call by $0.001 — small in absolute terms and 50% on a
+ * $0.002 RPC call.
+ */
+export function basePriceForPath(apiPath: string): number | null {
+  const wallet = priceForPath(apiPath);
+  if (wallet === null) return null;
+  if (wallet <= 0) return wallet; // free stays free on both rails
+  const base = wallet - GATEWAY_TRANSACTION_FEE_USD;
+  return base > 0 ? +base.toFixed(6) : wallet;
 }
 
 /**

--- a/src/tools/defillama.ts
+++ b/src/tools/defillama.ts
@@ -5,11 +5,11 @@
  *
  * Five tools, each filtered + formatted on the way back so we don't dump
  * 5–10 MB of raw DefiLlama JSON into agent context:
- *  - DeFiLlamaProtocols   $0.005/call — top-N protocols by TVL
- *  - DeFiLlamaProtocol    $0.005/call — single protocol detail
- *  - DeFiLlamaChains      $0.005/call — TVL ranked by chain
- *  - DeFiLlamaYields      $0.005/call — yield pools, filtered + ranked
- *  - DeFiLlamaPrice       $0.001/call — token price lookup
+ *  - DeFiLlamaProtocols   $0.0050/call base (+$0.001 on a wallet) — top-N protocols by TVL
+ *  - DeFiLlamaProtocol    $0.0050/call base (+$0.001 on a wallet) — single protocol detail
+ *  - DeFiLlamaChains      $0.0050/call base (+$0.001 on a wallet) — TVL ranked by chain
+ *  - DeFiLlamaYields      $0.0050/call base (+$0.001 on a wallet) — yield pools, filtered + ranked
+ *  - DeFiLlamaPrice       $0.0050/call base (+$0.001 on a wallet) — token price lookup
  *
  * DefiLlama is Apache 2.0 / "free for public and commercial use" — the
  * BlockRun gateway adds metering + (future) caching/reliability layers,
@@ -202,7 +202,7 @@ export const defiLlamaProtocolsCapability: CapabilityHandler = {
     description:
       'Rank DeFi protocols by total value locked (TVL) across all chains, optionally filtered by category, chain, or minimum TVL. ' +
       'Returns the top-N protocols (default 20), each with TVL, 24h/7d change, chain breakdown, and slug. ' +
-      'Uses BlockRun gateway → DefiLlama. $0.005 per call. ' +
+      'Uses BlockRun gateway → DefiLlama. $0.0050 per call base, plus a $0.001 settlement fee when paying from a wallet. ' +
       'Categories include: Lending, Liquid Staking, Bridge, Dexes, CDP, Yield, Yield Aggregator, Derivatives, Stablecoins, Insurance, etc.',
     input_schema: {
       type: 'object',
@@ -286,7 +286,7 @@ export const defiLlamaProtocolCapability: CapabilityHandler = {
       'Detailed TVL + chain breakdown for a single DeFi protocol identified by DefiLlama slug ' +
       '(e.g. "aave", "uniswap", "lido", "jito", "marinade-finance"). ' +
       'Returns TVL across each chain it operates on, recent change, audits, social. ' +
-      '$0.005 per call. To find a slug, run DeFiLlamaProtocols first.',
+      '$0.0050 per call base, plus a $0.001 settlement fee when paying from a wallet. To find a slug, run DeFiLlamaProtocols first.',
     input_schema: {
       type: 'object',
       properties: {
@@ -355,7 +355,7 @@ export const defiLlamaChainsCapability: CapabilityHandler = {
   spec: {
     name: 'DeFiLlamaChains',
     description:
-      'TVL ranking across every chain DefiLlama tracks. Default returns top 20 by TVL. $0.005 per call.',
+      'TVL ranking across every chain DefiLlama tracks. Default returns top 20 by TVL. $0.0050 per call base, plus a $0.001 settlement fee when paying from a wallet.',
     input_schema: {
       type: 'object',
       properties: {
@@ -419,7 +419,7 @@ export const defiLlamaYieldsCapability: CapabilityHandler = {
     name: 'DeFiLlamaYields',
     description:
       'Search DeFi yield pools (lending, LPs, vaults, staking) by symbol/chain/project, ranked by APY. ' +
-      'Returns top-N pools (default 10). $0.005 per call. ' +
+      'Returns top-N pools (default 10). $0.0050 per call base, plus a $0.001 settlement fee when paying from a wallet. ' +
       'Default filters: TVL > $1M (avoid microcaps), APY > 0. Override via params. ' +
       'Use stablecoin_only=true for "where can my USDC earn?" queries.',
     input_schema: {
@@ -515,7 +515,7 @@ export const defiLlamaPriceCapability: CapabilityHandler = {
   spec: {
     name: 'DeFiLlamaPrice',
     description:
-      'Token price lookup via DefiLlama (covers thousands of tokens — anything DEX-listed). $0.001 per call. ' +
+      'Token price lookup via DefiLlama (covers thousands of tokens — anything DEX-listed). $0.0050 per call base, plus a $0.001 settlement fee when paying from a wallet. ' +
       'Coin identifier syntax: "{platform}:{address}" or "coingecko:{slug}". ' +
       'Examples: "coingecko:bitcoin" (BTC USD), "ethereum:0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" (WETH), ' +
       '"solana:So11111111111111111111111111111111111111112" (SOL/wSOL), ' +

--- a/src/tools/defillama.ts
+++ b/src/tools/defillama.ts
@@ -28,7 +28,7 @@ import {
 } from '@blockrun/llm';
 import type { CapabilityHandler, CapabilityResult, ExecutionScope } from '../agent/types.js';
 import { loadChain, VERSION} from '../config.js';
-import { resolveCharge } from '../payments/price-catalog.js';
+import { chargeFromResponse, resolveCharge } from '../payments/price-catalog.js';
 import { gatewayBase, gatewayHeaders } from '../payments/auth-mode.js';
 import { logger } from '../logger.js';
 import { recordUsage } from '../stats/tracker.js';
@@ -84,7 +84,7 @@ async function getWithPayment<T>(path: string, ctx: ExecutionScope): Promise<T> 
     // stats / audit AND count against the --max-spend ceiling (parity with surf.ts).
     // See rpc.ts — `paidUsd` is 0 whenever no 402 happened, which is every
     // call in API-key mode.
-    const charge = resolveCharge({ apiPath: endpoint, settledUsd: paidUsd });
+    const charge = resolveCharge({ apiPath: endpoint, chargedUsd: chargeFromResponse(response), settledUsd: paidUsd });
     try { recordUsage(`DeFiLlama:${path}`, 0, 0, charge.usd, Date.now() - startedAt, false, charge.estimated); } catch { /* best-effort */ }
     return (await response.json()) as T;
   } finally {

--- a/src/tools/defillama.ts
+++ b/src/tools/defillama.ts
@@ -5,11 +5,11 @@
  *
  * Five tools, each filtered + formatted on the way back so we don't dump
  * 5–10 MB of raw DefiLlama JSON into agent context:
- *  - DeFiLlamaProtocols   $0.0050/call base (+$0.001 on a wallet) — top-N protocols by TVL
- *  - DeFiLlamaProtocol    $0.0050/call base (+$0.001 on a wallet) — single protocol detail
- *  - DeFiLlamaChains      $0.0050/call base (+$0.001 on a wallet) — TVL ranked by chain
- *  - DeFiLlamaYields      $0.0050/call base (+$0.001 on a wallet) — yield pools, filtered + ranked
- *  - DeFiLlamaPrice       $0.0050/call base (+$0.001 on a wallet) — token price lookup
+ *  - DeFiLlamaProtocols   $0.0050/call base (plus a $0.001 settlement fee on a wallet) — top-N protocols by TVL
+ *  - DeFiLlamaProtocol    $0.0050/call base (plus a $0.001 settlement fee on a wallet) — single protocol detail
+ *  - DeFiLlamaChains      $0.0050/call base (plus a $0.001 settlement fee on a wallet) — TVL ranked by chain
+ *  - DeFiLlamaYields      $0.0050/call base (plus a $0.001 settlement fee on a wallet) — yield pools, filtered + ranked
+ *  - DeFiLlamaPrice       $0.0050/call base (plus a $0.001 settlement fee on a wallet) — token price lookup
  *
  * DefiLlama is Apache 2.0 / "free for public and commercial use" — the
  * BlockRun gateway adds metering + (future) caching/reliability layers,

--- a/src/tools/exa.ts
+++ b/src/tools/exa.ts
@@ -30,7 +30,7 @@ import {
 } from '@blockrun/llm';
 import type { CapabilityHandler, CapabilityResult, ExecutionScope } from '../agent/types.js';
 import { loadChain, VERSION} from '../config.js';
-import { resolveCharge } from '../payments/price-catalog.js';
+import { chargeFromResponse, resolveCharge } from '../payments/price-catalog.js';
 import { gatewayBase, gatewayHeaders } from '../payments/auth-mode.js';
 import { frameUntrusted } from './untrusted.js';
 import { recordUsage } from '../stats/tracker.js';
@@ -43,6 +43,8 @@ const GEN_TIMEOUT_MS = 30_000;
 interface PaidResponse<T> {
   data: T;
   settled: boolean;  // true when a 402 payment was signed AND the retry succeeded
+  /** From `x-blockrun-cost-usd`. Null when the gateway stated no charge. */
+  chargedUsd: number | null;
   latencyMs: number;
 }
 
@@ -96,7 +98,12 @@ async function postWithPayment<T>(
       throw new Error(`Exa ${path} failed (${response.status}): ${errText.slice(0, 200)}`);
     }
 
-    return { data: (await response.json()) as T, settled, latencyMs: Date.now() - start };
+    return {
+      data: (await response.json()) as T,
+      settled,
+      chargedUsd: chargeFromResponse(response),
+      latencyMs: Date.now() - start,
+    };
   } finally {
     clearTimeout(timeout);
     ctx.abortSignal.removeEventListener('abort', onAbort);
@@ -113,11 +120,15 @@ async function postWithPayment<T>(
 // `costDollars`, so prefer that; otherwise price from the catalog. Returning
 // early on !settled — as this did before key mode — would record $0 for real
 // spend.
-function recordExaSpend(path: string, settled: boolean, reportedUsd: number | undefined, fallbackUsd: number, latencyMs: number): void {
-  const charge = settled
-    // Settled through x402: the gateway-reported charge, else the list price.
-    // Either way it reflects money that demonstrably moved.
-    ? { usd: reportedUsd && reportedUsd > 0 ? reportedUsd : fallbackUsd, estimated: false }
+function recordExaSpend(path: string, settled: boolean, chargedUsd: number | null, reportedUsd: number | undefined, fallbackUsd: number, latencyMs: number): void {
+  // `reportedUsd` is Exa's own costDollars — its upstream cost, NOT what
+  // BlockRun charged. Measured 2026-09-05: Exa said $0.007 on a call the
+  // gateway charged $0.010 for. It is no longer treated as exact anywhere;
+  // x-blockrun-cost-usd is the authority when present.
+  const charge = chargedUsd !== null
+    ? { usd: chargedUsd, estimated: false }
+    : settled
+    ? { usd: fallbackUsd, estimated: false }
     : resolveCharge({ apiPath: path, reportedUsd, fallbackUsd });
   if (charge.usd <= 0) return;
   try { recordUsage(`Exa:${path}`, 0, 0, charge.usd, latencyMs, false, charge.estimated); } catch { /* best-effort accounting */ }
@@ -249,10 +260,10 @@ export const exaSearchCapability: CapabilityHandler = {
     if (!params.query) return { output: 'Error: query is required', isError: true };
 
     try {
-      const { data: res, settled, latencyMs } = await postWithPayment<ExaSearchResponse>('/v1/exa/search', params, ctx);
+      const { data: res, settled, chargedUsd, latencyMs } = await postWithPayment<ExaSearchResponse>('/v1/exa/search', params, ctx);
       const body = res.data ?? res;
       const cost = body.costDollars?.total;
-      recordExaSpend('/v1/exa/search', settled, cost, 0.01, latencyMs);
+      recordExaSpend('/v1/exa/search', settled, chargedUsd, cost, 0.01, latencyMs);
       const hits = body.results ?? [];
       if (hits.length === 0) {
         return { output: `No Exa results for "${params.query}".` };
@@ -311,10 +322,10 @@ export const exaAnswerCapability: CapabilityHandler = {
     if (!params.query) return { output: 'Error: query is required', isError: true };
 
     try {
-      const { data: res, settled, latencyMs } = await postWithPayment<ExaAnswerResponse>('/v1/exa/answer', params, ctx);
+      const { data: res, settled, chargedUsd, latencyMs } = await postWithPayment<ExaAnswerResponse>('/v1/exa/answer', params, ctx);
       const body = res.data ?? res;
       const cost = body.costDollars?.total;
-      recordExaSpend('/v1/exa/answer', settled, cost, 0.01, latencyMs);
+      recordExaSpend('/v1/exa/answer', settled, chargedUsd, cost, 0.01, latencyMs);
       const ans = body.answer ?? '';
       const cites = body.citations ?? [];
       const lines: string[] = [ans];
@@ -383,11 +394,11 @@ export const exaReadUrlsCapability: CapabilityHandler = {
     }
 
     try {
-      const { data: res, settled, latencyMs } = await postWithPayment<ExaContentsResponse>('/v1/exa/contents', params, ctx);
+      const { data: res, settled, chargedUsd, latencyMs } = await postWithPayment<ExaContentsResponse>('/v1/exa/contents', params, ctx);
       const body = res.data ?? res;
       const cost = body.costDollars?.total;
       // $0.002/URL list price as the floor when the gateway omits costDollars.
-      recordExaSpend('/v1/exa/contents', settled, cost, 0.002 * params.urls.length, latencyMs);
+      recordExaSpend('/v1/exa/contents', settled, chargedUsd, cost, 0.002 * params.urls.length, latencyMs);
       const results = body.results ?? [];
       if (results.length === 0) {
         return { output: `No readable content returned for the ${params.urls.length} URL(s).` };

--- a/src/tools/exa.ts
+++ b/src/tools/exa.ts
@@ -5,7 +5,7 @@
  * Three tools:
  *  - ExaSearch     — semantic search for URLs ($0.01/call)
  *  - ExaAnswer     — synthesized answer with citations ($0.01/call)
- *  - ExaReadUrls   — batch-fetch clean Markdown from URLs ($0.002/URL)
+ *  - ExaReadUrls   — batch-fetch clean Markdown from URLs ($0.0030/URL)
  *
  * Why these matter for an economic agent: ExaAnswer is Perplexity-in-a-
  * tool — the agent gets a grounded reply with sources, avoiding the
@@ -230,7 +230,7 @@ export const exaSearchCapability: CapabilityHandler = {
   spec: {
     name: 'ExaSearch',
     description:
-      'Neural web search via Exa ($0.01/call). Returns a ranked list of ' +
+      'Neural web search via Exa ($0.0100/call base, +$0.001 settlement fee on a wallet). Returns a ranked list of ' +
       'URLs + titles for a natural-language query. Understands meaning, ' +
       'not just keywords. Optional `category` narrows to github / news / ' +
       '`research paper` / tweet / pdf / company / etc. Prefer this over ' +
@@ -304,7 +304,7 @@ export const exaAnswerCapability: CapabilityHandler = {
     name: 'ExaAnswer',
     description:
       "Ask a factual question, get a synthesized answer with real source " +
-      "citations ($0.01/call). Like Perplexity in a tool — grounded in " +
+      "citations ($0.0100/call base, +$0.001 settlement fee on a wallet). Like Perplexity in a tool — grounded in " +
       "live web content, not LLM memory. Best for 'what is X?', 'how does " +
       "Y work?', 'what's the current state of Z?'. Prefer this over " +
       "chaining ExaSearch + ExaReadUrls + LLM synthesis when the user " +
@@ -367,7 +367,7 @@ export const exaReadUrlsCapability: CapabilityHandler = {
   spec: {
     name: 'ExaReadUrls',
     description:
-      "Batch-fetch clean Markdown content from a list of URLs ($0.002/URL). " +
+      "Batch-fetch clean Markdown content from a list of URLs ($0.0020/URL base, +$0.001 settlement fee on a wallet). " +
       "Up to 100 URLs per call. Much cheaper than chaining 100× WebFetch, " +
       "and returns text already stripped of HTML/boilerplate — ready to " +
       "feed into an LLM context window. Prefer over WebFetch when reading " +

--- a/src/tools/exa.ts
+++ b/src/tools/exa.ts
@@ -230,7 +230,7 @@ export const exaSearchCapability: CapabilityHandler = {
   spec: {
     name: 'ExaSearch',
     description:
-      'Neural web search via Exa ($0.0100/call base, +$0.001 settlement fee on a wallet). Returns a ranked list of ' +
+      'Neural web search via Exa ($0.0100/call base, plus a $0.001 settlement fee on a wallet). Returns a ranked list of ' +
       'URLs + titles for a natural-language query. Understands meaning, ' +
       'not just keywords. Optional `category` narrows to github / news / ' +
       '`research paper` / tweet / pdf / company / etc. Prefer this over ' +
@@ -304,7 +304,7 @@ export const exaAnswerCapability: CapabilityHandler = {
     name: 'ExaAnswer',
     description:
       "Ask a factual question, get a synthesized answer with real source " +
-      "citations ($0.0100/call base, +$0.001 settlement fee on a wallet). Like Perplexity in a tool — grounded in " +
+      "citations ($0.0100/call base, plus a $0.001 settlement fee on a wallet). Like Perplexity in a tool — grounded in " +
       "live web content, not LLM memory. Best for 'what is X?', 'how does " +
       "Y work?', 'what's the current state of Z?'. Prefer this over " +
       "chaining ExaSearch + ExaReadUrls + LLM synthesis when the user " +
@@ -367,7 +367,7 @@ export const exaReadUrlsCapability: CapabilityHandler = {
   spec: {
     name: 'ExaReadUrls',
     description:
-      "Batch-fetch clean Markdown content from a list of URLs ($0.0020/URL base, +$0.001 settlement fee on a wallet). " +
+      "Batch-fetch clean Markdown content from a list of URLs ($0.0020/URL base, plus a $0.001 settlement fee on a wallet). " +
       "Up to 100 URLs per call. Much cheaper than chaining 100× WebFetch, " +
       "and returns text already stripped of HTML/boilerplate — ready to " +
       "feed into an LLM context window. Prefer over WebFetch when reading " +

--- a/src/tools/prediction.ts
+++ b/src/tools/prediction.ts
@@ -48,7 +48,7 @@ import {
 } from '@blockrun/llm';
 import type { CapabilityHandler, CapabilityResult, ExecutionScope } from '../agent/types.js';
 import { loadChain, VERSION} from '../config.js';
-import { resolveCharge } from '../payments/price-catalog.js';
+import { chargeFromResponse, resolveCharge } from '../payments/price-catalog.js';
 import { gatewayBase, gatewayHeaders } from '../payments/auth-mode.js';
 import { logger } from '../logger.js';
 import { recordFetch } from '../trading/providers/telemetry.js';
@@ -135,6 +135,7 @@ async function getWithPayment<T>(path: string, query: Record<string, string | nu
     // to this module's own price table, then to the published catalog.
     const charge = resolveCharge({
       apiPath: endpoint,
+      chargedUsd: chargeFromResponse(response),
       settledUsd: costRecorded,
       fallbackUsd: priceForPath(path),
     });

--- a/src/tools/realface.ts
+++ b/src/tools/realface.ts
@@ -38,7 +38,7 @@ import {
 } from '@blockrun/llm';
 import type { CapabilityHandler, CapabilityResult, ExecutionScope } from '../agent/types.js';
 import { loadChain, USER_AGENT} from '../config.js';
-import { resolveCharge } from '../payments/price-catalog.js';
+import { chargeFromResponse, resolveCharge } from '../payments/price-catalog.js';
 import { gatewayBase, gatewayHeaders } from '../payments/auth-mode.js';
 import { recordUsage } from '../stats/tracker.js';
 import { logger } from '../logger.js';
@@ -224,7 +224,7 @@ async function actionEnroll(
   if (!res.ok) paidUsd = 0;
   // 0 whenever no 402 was settled, which is every call in API-key mode.
   const charge = res.ok
-    ? resolveCharge({ apiPath: url, settledUsd: paidUsd })
+    ? resolveCharge({ apiPath: url, chargedUsd: chargeFromResponse(res), settledUsd: paidUsd })
     : { usd: 0, estimated: false };
   try { recordUsage('RealFace:enroll', 0, 0, charge.usd, Date.now() - start, false, charge.estimated); } catch { /* best-effort */ }
 

--- a/src/tools/rpc.ts
+++ b/src/tools/rpc.ts
@@ -29,7 +29,7 @@ import {
 } from '@blockrun/llm';
 import type { CapabilityHandler, CapabilityResult, ExecutionScope } from '../agent/types.js';
 import { loadChain, VERSION} from '../config.js';
-import { resolveCharge } from '../payments/price-catalog.js';
+import { chargeFromResponse, resolveCharge } from '../payments/price-catalog.js';
 import { gatewayBase, gatewayHeaders } from '../payments/auth-mode.js';
 import { logger } from '../logger.js';
 import { recordUsage } from '../stats/tracker.js';
@@ -127,7 +127,7 @@ async function postRpcWithPayment(
     // `paidUsd` is only ever set by the 402 branch, so in API-key mode — where
     // the gateway settles silently and never sends a 402 — it stays 0. Price the
     // call from the published catalog instead of recording a free call.
-    const charge = resolveCharge({ apiPath: endpoint, settledUsd: paidUsd });
+    const charge = resolveCharge({ apiPath: endpoint, chargedUsd: chargeFromResponse(response), settledUsd: paidUsd });
     try { recordUsage(`MultiChainRPC:${network}`, 0, 0, charge.usd, Date.now() - startedAt, false, charge.estimated); } catch { /* best-effort */ }
     return {
       body: await response.json(),

--- a/src/tools/rpc.ts
+++ b/src/tools/rpc.ts
@@ -1,7 +1,7 @@
 /**
  * Multi-chain RPC — read-only JSON-RPC across 40+ chains via the BlockRun
  * `/v1/rpc/{network}` endpoint (Tatum gateway). x402-paid against the user's
- * USDC wallet, flat $0.002 per call.
+ * USDC wallet, flat $0.0020 base + $0.001 settlement fee (measured 2026-09-05).
  *
  * For a trading agent this covers the on-chain reads the dedicated tools don't:
  * native + ERC-20 balances on any chain, contract reads (eth_call), gas price,
@@ -220,7 +220,7 @@ export const multiChainRpcCapability: CapabilityHandler = {
     name: 'MultiChainRPC',
     description:
       'Read-only JSON-RPC against 40+ chains through the BlockRun gateway (one endpoint, no per-chain key). ' +
-      '$0.002 per call (USDC). Use for on-chain reads the other tools do not cover: native/token balances on any ' +
+      '$0.0020 per call, plus a $0.001 settlement fee when paying from a wallet. Use for on-chain reads the other tools do not cover: native/token balances on any ' +
       'chain, contract reads (eth_call), gas price, nonce, block height, and tx receipt checks ("did my swap land?"). ' +
       'EVM chains speak eth_* (eth_blockNumber, eth_getBalance, eth_call, eth_gasPrice, eth_getTransactionReceipt, ...); ' +
       'Solana speaks getSlot/getBalance/getAccountInfo/getTransaction; Bitcoin-family speaks getblockcount etc. ' +

--- a/src/tools/surf.ts
+++ b/src/tools/surf.ts
@@ -28,7 +28,7 @@ import {
 } from '@blockrun/llm';
 import type { CapabilityHandler, CapabilityResult, ExecutionScope } from '../agent/types.js';
 import { loadChain, USER_AGENT} from '../config.js';
-import { chargeFromResponse, resolveCharge } from '../payments/price-catalog.js';
+import { basePriceForPath, chargeFromResponse, resolveCharge } from '../payments/price-catalog.js';
 import { gatewayBase, gatewayHeaders } from '../payments/auth-mode.js';
 import { frameUntrusted } from './untrusted.js';
 import { recordUsage } from '../stats/tracker.js';
@@ -83,7 +83,7 @@ const CHAIN_ENDPOINTS: SurfEndpoint[] = [
   { path: 'onchain/tx', method: 'GET', required: ['hash', 'chain'], desc: 'Transaction details by hash.' },
   { path: 'onchain/schema', method: 'GET', required: [], desc: 'Schema introspection for the SQL tables.' },
   { path: 'onchain/query', method: 'POST', required: [], desc: 'Structured chain query (POST body).' },
-  { path: 'onchain/sql', method: 'POST', required: [], desc: 'Raw SQL against 80+ indexed chain tables (POST body, Tier-3 $0.02).' },
+  { path: 'onchain/sql', method: 'POST', required: [], desc: 'Raw SQL against 80+ indexed chain tables (POST body).' },
   { path: 'token/tokenomics', method: 'GET', required: [], desc: 'Token supply / unlock / distribution.' },
   { path: 'token/dex-trades', method: 'GET', required: ['address'], desc: 'Recent DEX trades for a token.' },
   { path: 'token/holders', method: 'GET', required: ['address', 'chain'], desc: 'Top holders / concentration.' },
@@ -273,6 +273,33 @@ async function callSurf(
 
 // ── Tool specs ───────────────────────────────────────────────────────────────
 
+/**
+ * Price sentence for the tool description, read from the catalog rather than
+ * typed in.
+ *
+ * This used to read "Tier-1 $0.001, Tier-2 $0.005, Tier-3 $0.02", which the
+ * payment layer had long since replaced with one flat rate. Measured against
+ * the authoritative 402 on 2026-09-05: every Surf endpoint quotes $0.0085, so
+ * the description understated tier-1 by 8.5x and overstated tier-3 by 2.4x.
+ *
+ * That matters more than an inaccurate comment, because the agent reads this
+ * string to decide whether a call is worth making — it was being told the
+ * cheapest Surf call costs about a tenth of what it does. A hand-typed price
+ * is a published number with no owner; sourcing it from the catalog gives it
+ * one, and the guard test keeps literals from creeping back in.
+ *
+ * It states the BASE price and names the fee separately because there are two
+ * real prices per endpoint: the key rail charges the base, the wallet rail adds
+ * a settlement fee. One number cannot be right for both, and this phrasing is
+ * true on either.
+ */
+function surfPriceBlurb(): string {
+  const base = basePriceForPath('/v1/surf/market/ranking');
+  return base === null || base <= 0
+    ? 'Each call is charged per request; the 402 quote states the exact price.'
+    : `Flat $${base.toFixed(4)} per call, plus a $0.001 settlement fee when paying from a wallet.`;
+}
+
 function makeSurfTool(
   name: string,
   blurb: string,
@@ -285,7 +312,7 @@ function makeSurfTool(
       name,
       description:
         `${blurb} Picks an endpoint from a fixed list and signs the x402 USDC payment from the wallet automatically — ` +
-        `you do not build paths or handle payment. Tier-1 $0.001, Tier-2 $0.005, Tier-3 $0.02.\n\nEndpoints:\n${endpointList}`,
+        `you do not build paths or handle payment. ${surfPriceBlurb()}\n\nEndpoints:\n${endpointList}`,
       input_schema: {
         type: 'object',
         properties: {

--- a/src/tools/surf.ts
+++ b/src/tools/surf.ts
@@ -28,7 +28,7 @@ import {
 } from '@blockrun/llm';
 import type { CapabilityHandler, CapabilityResult, ExecutionScope } from '../agent/types.js';
 import { loadChain, USER_AGENT} from '../config.js';
-import { resolveCharge } from '../payments/price-catalog.js';
+import { chargeFromResponse, resolveCharge } from '../payments/price-catalog.js';
 import { gatewayBase, gatewayHeaders } from '../payments/auth-mode.js';
 import { frameUntrusted } from './untrusted.js';
 import { recordUsage } from '../stats/tracker.js';
@@ -251,7 +251,7 @@ async function callSurf(
     // Fall back to the catalog price so Surf spend still counts against
     // --max-spend and shows in stats.
     const charge = response.ok
-      ? resolveCharge({ apiPath: url, settledUsd: paidUsd })
+      ? resolveCharge({ apiPath: url, chargedUsd: chargeFromResponse(response), settledUsd: paidUsd })
       : { usd: 0, estimated: false };
     try { recordUsage(`${toolName}:${entry.path}`, 0, 0, charge.usd, Date.now() - start, false, charge.estimated); } catch { /* best-effort */ }
 

--- a/src/tools/surf.ts
+++ b/src/tools/surf.ts
@@ -29,6 +29,7 @@ import {
 import type { CapabilityHandler, CapabilityResult, ExecutionScope } from '../agent/types.js';
 import { loadChain, USER_AGENT} from '../config.js';
 import { basePriceForPath, chargeFromResponse, resolveCharge } from '../payments/price-catalog.js';
+import { GATEWAY_TRANSACTION_FEE_USD } from '../gateway-models.js';
 import { gatewayBase, gatewayHeaders } from '../payments/auth-mode.js';
 import { frameUntrusted } from './untrusted.js';
 import { recordUsage } from '../stats/tracker.js';
@@ -297,7 +298,8 @@ function surfPriceBlurb(): string {
   const base = basePriceForPath('/v1/surf/market/ranking');
   return base === null || base <= 0
     ? 'Each call is charged per request; the 402 quote states the exact price.'
-    : `Flat $${base.toFixed(4)} per call, plus a $0.001 settlement fee when paying from a wallet.`;
+    : `Flat $${base.toFixed(4)} per call, plus a $${GATEWAY_TRANSACTION_FEE_USD.toFixed(3)} `
+      + 'settlement fee when paying from a wallet.';
 }
 
 function makeSurfTool(

--- a/test/api-key.local.mjs
+++ b/test/api-key.local.mjs
@@ -270,7 +270,7 @@ test('free endpoints price at zero, unknown endpoints price as null', () => {
   assert.equal(catalog.priceForPath('/v1/chat/completions'), null);
 });
 
-test('resolveCharge prefers a settled amount, then a reported one, then the catalog', () => {
+test('resolveCharge prefers a gateway charge, then a settlement, then the catalog', () => {
   catalog.__resetPriceCatalog();
 
   const settled = catalog.resolveCharge({
@@ -279,11 +279,14 @@ test('resolveCharge prefers a settled amount, then a reported one, then the cata
   assert.equal(settled.usd, 0.0085);
   assert.equal(settled.estimated, false, 'a settled x402 amount is exact');
 
-  const reported = catalog.resolveCharge({
-    apiPath: '/v1/exa/search', reportedUsd: 0.007,
+  // This used to assert reportedUsd was exact. It is not: an upstream's own
+  // costDollars is its cost, not BlockRun's charge — see the dedicated test
+  // below. x-blockrun-cost-usd replaced it as the authority.
+  const charged = catalog.resolveCharge({
+    apiPath: '/v1/exa/search', chargedUsd: 0.01, reportedUsd: 0.007,
   });
-  assert.equal(reported.usd, 0.007);
-  assert.equal(reported.estimated, false, 'a gateway-reported charge is exact');
+  assert.equal(charged.usd, 0.01);
+  assert.equal(charged.estimated, false, 'the gateway stating its charge is exact');
 
   const listed = catalog.resolveCharge({ apiPath: '/v1/surf/market/ranking' });
   assert.ok(listed.usd > 0, 'key-mode calls must never record zero for paid work');
@@ -318,6 +321,57 @@ test('the price catalog is read from the Base origin, the only host that publish
   );
   // A 200 carrying no services[] must be reported, never swallowed.
   assert.match(src, /returned no services/);
+});
+
+
+// ─── The gateway's own charge header ────────────────────────────────────
+
+const hdr = (v) => ({ headers: { get: (n) => (n === 'x-blockrun-cost-usd' && v !== undefined ? v : null) } });
+
+test('chargeFromResponse treats 0 as a value and everything malformed as absent', () => {
+  assert.equal(catalog.chargeFromResponse(hdr('0.010000')), 0.01);
+  // A charge that genuinely settled at zero is written explicitly, and must be
+  // distinguishable from a response that states no charge at all.
+  assert.equal(catalog.chargeFromResponse(hdr('0.000000')), 0);
+  assert.equal(catalog.chargeFromResponse(hdr(undefined)), null, 'absent');
+  // Number('') is 0 in JS — booking that against a billed call is the bug.
+  assert.equal(catalog.chargeFromResponse(hdr('')), null, 'empty is absent, not zero');
+  assert.equal(catalog.chargeFromResponse(hdr('   ')), null);
+  assert.equal(catalog.chargeFromResponse(hdr('abc')), null, 'malformed is absent');
+  assert.equal(catalog.chargeFromResponse(hdr('-1')), null, 'negative is absent');
+});
+
+test('remainingCreditFromResponse follows the same rules', () => {
+  const rc = (v) => ({ headers: { get: (n) => (n === 'x-blockrun-credit-remaining-usd' ? v : null) } });
+  assert.equal(catalog.remainingCreditFromResponse(rc('41.998000')), 41.998);
+  assert.equal(catalog.remainingCreditFromResponse(rc('0.000000')), 0, 'a real zero balance');
+  // Absent on ungated accounts, which have no ceiling. Correct, not a failure.
+  assert.equal(catalog.remainingCreditFromResponse(rc(null)), null);
+  assert.equal(catalog.remainingCreditFromResponse(rc('')), null);
+});
+
+test('a gateway-stated charge outranks every other source, including zero', () => {
+  catalog.__resetPriceCatalog();
+  const c = catalog.resolveCharge({
+    apiPath: '/v1/exa/search', chargedUsd: 0.01, settledUsd: 0.02, reportedUsd: 0.007,
+  });
+  assert.equal(c.usd, 0.01);
+  assert.equal(c.estimated, false);
+
+  // 0 must not be swallowed by a truthiness check.
+  const zero = catalog.resolveCharge({ apiPath: '/v1/exa/search', chargedUsd: 0, fallbackUsd: 0.05 });
+  assert.equal(zero.usd, 0, 'an explicit zero charge is authoritative');
+  assert.equal(zero.estimated, false);
+});
+
+test("an upstream's self-reported cost is not what BlockRun charged", () => {
+  catalog.__resetPriceCatalog();
+  // Measured 2026-09-05: Exa reported costDollars $0.007 on a call the gateway
+  // charged $0.010 for. Booking $0.007 as exact was a wrong number carrying
+  // false confidence — worse than a hedged one.
+  const c = catalog.resolveCharge({ apiPath: '/v1/exa/search', reportedUsd: 0.007 });
+  assert.equal(c.estimated, true, 'a provider-reported cost is an estimate, not a charge');
+  assert.ok(c.usd > 0);
 });
 
 test('cleanup', () => {

--- a/test/api-key.local.mjs
+++ b/test/api-key.local.mjs
@@ -25,6 +25,7 @@ const auth = await import('../dist/payments/auth-mode.js');
 const { API_URLS, KEY_API_URL, BLOCKRUN_DIR, saveChain } = await import('../dist/config.js');
 const { redactSecrets } = await import('../dist/agent/secret-redact.js');
 const catalog = await import('../dist/payments/price-catalog.js');
+const { GATEWAY_TRANSACTION_FEE_USD } = await import('../dist/gateway-models.js');
 
 // Synthetic — shaped like a real key so the format checks are meaningful, but
 // not a credential. Never put a live key in a tracked file.
@@ -419,6 +420,17 @@ test('a price quoted in a tool description is the base, not the wallet quote', a
       );
     }
     assert.match(cap.spec.description, /settlement fee/, `${cap.spec.name} names the wallet-rail fee`);
+    // The fee figure needs an owner too. The gateway's constant has moved
+    // before — 0.001 to 0.002 and back — so a description that bakes it drifts
+    // on the next move exactly like the prices did.
+    const feeQuoted = [...cap.spec.description.matchAll(/\$(\d+\.\d{3,4})\s*settlement fee/g)]
+      .map((m) => Number(m[1]));
+    for (const f of feeQuoted) {
+      assert.ok(
+        Math.abs(f - GATEWAY_TRANSACTION_FEE_USD) < 1e-9,
+        `${cap.spec.name} states a $${f} settlement fee; the constant is $${GATEWAY_TRANSACTION_FEE_USD}`
+      );
+    }
   }
 });
 

--- a/test/api-key.local.mjs
+++ b/test/api-key.local.mjs
@@ -374,6 +374,76 @@ test("an upstream's self-reported cost is not what BlockRun charged", () => {
   assert.ok(c.usd > 0);
 });
 
+
+// ─── Prices restated in model-facing tool descriptions ──────────────────
+
+test('a price quoted in a tool description is the base, not the wallet quote', async () => {
+  // These strings are what the AGENT reads to decide whether a call is worth
+  // making, so a stale one changes spending behaviour, not just docs.
+  //
+  // There are TWO real prices per endpoint and one literal cannot serve both:
+  // the API-key rail charges the base, the wallet rail adds a settlement fee,
+  // and the 402 challenge / catalog both quote the wallet figure. Measured
+  // 2026-09-05 via x-blockrun-cost-usd — surf $0.0075 vs $0.0085, rpc $0.0020
+  // vs $0.0030, exa $0.0100 vs $0.0110, defillama $0.0050 vs $0.0060 — exactly
+  // one fee apart every time. The descriptions state the base and name the fee
+  // separately, which is true on either rail.
+  //
+  // Reads the built spec.description rather than the source file, so a comment
+  // recording what a price USED to be does not trip it.
+  catalog.__resetPriceCatalog();
+
+  const rpc = await import('../dist/tools/rpc.js');
+  const llama = await import('../dist/tools/defillama.js');
+  const exa = await import('../dist/tools/exa.js');
+
+  const cases = [
+    [rpc.multiChainRpcCapability, '/v1/rpc/base'],
+    [llama.defiLlamaProtocolsCapability, '/v1/defillama/protocols'],
+    [exa.exaSearchCapability, '/v1/exa/search'],
+    [exa.exaReadUrlsCapability, '/v1/exa/contents'],
+  ].filter(([cap]) => cap && cap.spec);
+  assert.ok(cases.length >= 3, 'found the capabilities to check');
+
+  for (const [cap, probePath] of cases) {
+    const base = catalog.basePriceForPath(probePath);
+    assert.ok(base > 0, `${probePath} should have a base price`);
+    // The fee is named as its own figure, so ignore it when checking the price.
+    const quoted = [...cap.spec.description.matchAll(/\$(\d+\.\d{3,4})/g)]
+      .map((m) => Number(m[1]))
+      .filter((n) => Math.abs(n - 0.001) > 1e-9);
+    for (const q of quoted) {
+      assert.ok(
+        Math.abs(q - base) < 0.0005,
+        `${cap.spec.name} quotes $${q}; the base price for ${probePath} is $${base}`
+      );
+    }
+    assert.match(cap.spec.description, /settlement fee/, `${cap.spec.name} names the wallet-rail fee`);
+  }
+});
+
+test('basePriceForPath is the catalog price less exactly one settlement fee', () => {
+  catalog.__resetPriceCatalog();
+  const wallet = catalog.priceForPath('/v1/surf/market/ranking');
+  const base = catalog.basePriceForPath('/v1/surf/market/ranking');
+  assert.ok(Math.abs((wallet - base) - 0.001) < 1e-9, 'one fee apart');
+  // Free endpoints stay free on both rails rather than going negative.
+  assert.equal(catalog.basePriceForPath('/v1/models'), 0);
+});
+
+test('surf quotes one flat price, computed rather than typed', async () => {
+  catalog.__resetPriceCatalog();
+  const surf = await import('../dist/tools/surf.js');
+  const desc = surf.surfMarketCapability.spec.description;
+
+  // The tier sentence was wrong in both directions at once: 8.5x under on
+  // tier 1, 2.4x over on tier 3.
+  assert.doesNotMatch(desc, /Tier-1/, 'the stale tier sentence is gone from the live description');
+  const base = catalog.basePriceForPath('/v1/surf/market/ranking');
+  assert.match(desc, new RegExp(`\\$${base.toFixed(4)}`), 'states the base price');
+  assert.match(desc, /settlement fee/, 'and names the wallet-rail fee separately');
+});
+
 test('cleanup', () => {
   clean();
   rmSync(TEST_HOME, { recursive: true, force: true });


### PR DESCRIPTION
The gateway now reports what it charged. Two things landed on `api.blockrun.ai` today (commit `57aa74f` — gated on `/api/health` before building against it):

- `x-blockrun-cost-usd` on the pre-priced service families
- `GET /v1/credits`, key-scoped balance, with `/v1/account` as an alias

Both are consumed here. **This answers the reconciliation gap 3.44.0 shipped with** — `franklin balance` no longer refuses to show a credit figure, and service-family calls are now booked exactly instead of estimated.

## The header found a bug in what shipped this morning

Franklin read Exa's own `costDollars` from the response body and booked it as **exact**.

| source | value |
|---|---|
| Exa `costDollars` (its upstream cost) | $0.007 |
| `x-blockrun-cost-usd` (what we were charged) | **$0.010** |

So the ledger carried a wrong number with false confidence — worse than a hedged one. `x-blockrun-cost-usd` is now the authority, and a provider's self-reported cost is demoted to an *estimate*, ranked below the catalog price. Verified live: that row now books `$0.010000` exact.

## Chat has no charge header, and never will

Chat settles *after* the answer is on the wire (`x-settlement-async: true`), so at header-writing time the amount does not exist. Producing it would mean holding the customer's response until the money lands. Chat stays reconstructed from tokens and stays tagged `estimated`.

## Absence is not zero

One parser serves both money headers. `0.000000` is a value; absent, empty, whitespace, malformed and negative are all null. `Number('')` is `0` in JS, and reading absence as $0 would zero out chat — the largest spend category. Covered by test.

## `franklin balance` reads real credit standing

```
Account:   pilot (ungated)
Remaining: no prepaid limit on this account
Spent:     $4.5524  (BlockRun, authoritative)
Local:     ~$9.3108  (Franklin's own tally, all time, both pay modes — expected to differ)
```

It branches on `billing_mode` rather than coalescing `remaining_usd`: an ungated account legitimately has no ceiling, and `remaining_usd ?? 0` would tell a paying customer they are broke. `blocked_reason` is mapped as an append-only code set, with unknown values surfaced as `blocked (CODE)` rather than swallowed.

## Known limitation, stated rather than hidden

`x-blockrun-credit-remaining-usd` is parsed but **deliberately not displayed**: it is read inside the reservation transaction and can understate under concurrency — the right error direction for a pre-run warning, the wrong one for a number shown to a user. `/v1/credits` is the authority for display.

That path is **written to spec and untested against a live gated account**. The pilot key is ungated, so the header is absent by design and I could not exercise it. Flagging that rather than implying it was verified.

716/716 tests pass. Verified live against `57aa74f`: `/v1/credits` 200, unauthenticated 401, exa carries the cost header, chat does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LZQ4mfQVs2JJhC2ALfyGjt