### PR TITLE
fix(tools): stop telling the user USDC moved when it was account credits

### DIFF
--- a/src/payments/billing-copy.ts
+++ b/src/payments/billing-copy.ts
@@ -1,0 +1,63 @@
+/**
+ * How Franklin describes a charge to the user and to the model.
+ *
+ * Key mode spends prepaid account credits; wallet mode signs USDC over x402.
+ * Saying "USDC charged" or "paid via x402" in key mode is not a cosmetic slip:
+ * these strings are the receipt the user reads, the approval prompt they say
+ * yes to, and the text the model reasons over when it decides whether it can
+ * afford the next call. Naming the wrong instrument makes all three wrong.
+ *
+ * Two rules, and the split matters:
+ *
+ *   Runtime output — receipts, approval prompts, cancellations — calls these
+ *   helpers, which read the mode at call time. `invalidateKey()` can demote a
+ *   session to wallet mode mid-run, so the mode must not be captured earlier.
+ *
+ *   Static `spec.description` text is built once at module load, before any
+ *   mode is settled and with no way to re-render afterwards. It must be
+ *   phrased so it is true in BOTH modes — state the price, not the rail:
+ *   "Costs $0.001 per call", never "Costs $0.001 USDC from the wallet".
+ *   These helpers deliberately do not serve that case.
+ */
+
+import { isKeyMode } from './auth-mode.js';
+
+function fmt(usd: number): string {
+  // Sub-cent prices are real here ($0.001 tiers), so keep enough places to
+  // avoid rendering them as $0.00.
+  return usd < 0.01 ? `$${usd.toFixed(4)}` : `$${usd.toFixed(2)}`;
+}
+
+/**
+ * Parenthetical for a completed charge, e.g. `($5.00 USDC charged)` or
+ * `(billed to account credits)`. Key mode states no amount: the local figure
+ * is an estimate and the account ledger is authoritative.
+ */
+export function chargedNote(usd: number): string {
+  return isKeyMode()
+    ? 'billed to account credits — see Activity at user.blockrun.ai'
+    : `${fmt(usd)} USDC charged`;
+}
+
+/** Sentence for an action that was cancelled or never dispatched. */
+export function noChargeNote(): string {
+  return isKeyMode() ? 'No account credits were spent.' : 'No USDC was spent.';
+}
+
+/** Trailing reassurance on an approval prompt, before the user answers. */
+export function cancelHint(): string {
+  return isKeyMode()
+    ? 'No account credits are spent if you cancel.'
+    : 'No USDC is spent if you cancel.';
+}
+
+/**
+ * Italic receipt line appended to a markdown tool result, e.g.
+ * `_$0.005 paid via x402._`. In key mode the rail is wrong AND the amount is
+ * unverifiable locally, so it names neither.
+ */
+export function receiptLine(usd: number): string {
+  return isKeyMode()
+    ? '_Billed to account credits._'
+    : `_${fmt(usd)} paid via x402._`;
+}

--- a/src/tools/blockrun.ts
+++ b/src/tools/blockrun.ts
@@ -240,7 +240,7 @@ export const blockrunCapability: CapabilityHandler = {
   spec: {
     name: 'BlockRun',
     description:
-      'Call any BlockRun gateway endpoint. Signs an x402 USDC payment from the user wallet, retries on HTTP 402, and returns the response. ' +
+      'Call any BlockRun gateway endpoint. Billed to account credits or, in wallet mode, by signing an x402 USDC payment and retrying on HTTP 402. ' +
       'Use this for crypto data (Surf — markets, on-chain, social), AI inference (chat / image / video / music), prediction markets, DeFi data, and any other API exposed under https://blockrun.ai/marketplace. ' +
       'For phone and voice, prefer the typed tools (ListPhoneNumbers, BuyPhoneNumber, RenewPhoneNumber, ReleasePhoneNumber, PhoneLookup, PhoneFraudCheck, VoiceCall, VoiceStatus) — they spell out cost, required fields, and the buy-number-first requirement. ' +
       'The path must start with "/v1/" or "/.well-known/". ' +

--- a/src/tools/imagegen.ts
+++ b/src/tools/imagegen.ts
@@ -26,6 +26,7 @@ import { findModel, estimateCostUsd, GATEWAY_MARGIN, type GatewayModel } from '.
 import { logger } from '../logger.js';
 import { ssrfSafeFetch } from './ssrf.js';
 import { isWalletKeyPath } from './sensitive-paths.js';
+import { noChargeNote, cancelHint } from '../payments/billing-copy.js';
 
 interface ImageGenInput {
   prompt: string;
@@ -352,7 +353,7 @@ function buildExecute(deps: ImageGenDeps) {
           output:
             `## Image generation skipped\n` +
             `- ${decision.reason}\n\n` +
-            `No USDC was spent. Choose a cheaper model/size or raise the ` +
+            `${noChargeNote()} Choose a cheaper model/size or raise the ` +
             `content budget before trying again.`,
         };
       }
@@ -368,11 +369,11 @@ function buildExecute(deps: ImageGenDeps) {
       const priceNote = est > 0 ? ` for ~$${est.toFixed(2)}` : '';
       const countNote = n > 1 ? `${n} images` : 'an image';
       const answer = await ctx.onAskUser(
-        `Generate ${countNote} with ${imageModel}${priceNote}? No USDC is spent if you cancel.`,
+        `Generate ${countNote} with ${imageModel}${priceNote}? ${cancelHint()}`,
         ['Generate', 'Cancel'],
       );
       if (answer !== 'Generate') {
-        return { output: `## Image generation cancelled\n\nNo USDC was spent.` };
+        return { output: `## Image generation cancelled\n\n${noChargeNote()}` };
       }
     }
 
@@ -805,7 +806,7 @@ export function createImageGenCapability(deps: ImageGenDeps = {}): CapabilityHan
         "Generate or edit an image. Text-to-image from a prompt, or " +
         "image-to-image when you pass a reference image (style transfer, " +
         "character consistency, edits). Supports mask-based inpainting and " +
-        "multi-image fusion. Costs USDC from the user's wallet — confirm " +
+        "multi-image fusion. Billed per image — confirm " +
         "before generating. Saves to local file(s). Default size: 1024x1024. " +
         "Do NOT call repeatedly to iterate on style — ask the user first. " +
         "Pass contentId to attach the result to an existing Content piece: " +

--- a/src/tools/modal.ts
+++ b/src/tools/modal.ts
@@ -42,6 +42,7 @@ import { gatewayBase, gatewayHeaders, isKeyMode } from '../payments/auth-mode.js
 import { walletReservation, AMBIGUOUS_GRACE_MS, type ReservationToken } from '../wallet/reservation.js';
 import { recordUsage } from '../stats/tracker.js';
 import { logger } from '../logger.js';
+import { noChargeNote } from '../payments/billing-copy.js';
 
 // ─── Pricing table (probed from /.well-known/x402 + 402 responses) ─────────
 const CREATE_PRICE_USD: Record<string, number> = {
@@ -456,7 +457,7 @@ export const modalCreateCapability: CapabilityHandler = {
       try {
         const answer = await ctx.onAskUser(lines.join('\n'), ['Approve', 'Cancel']);
         if (answer !== 'Approve') {
-          return { output: '## Sandbox creation cancelled\n\nNo USDC was spent.' };
+          return { output: `## Sandbox creation cancelled\n\n${noChargeNote()}` };
         }
       } catch {
         // askUser failed (UI gone) — fall through and create. Better than

--- a/src/tools/musicgen.ts
+++ b/src/tools/musicgen.ts
@@ -34,6 +34,7 @@ import type { ContentLibrary } from '../content/library.js';
 import { isWalletKeyPath } from './sensitive-paths.js';
 import { findModel, estimateCostUsd, type GatewayModel } from '../gateway-models.js';
 import { recordUsage } from '../stats/tracker.js';
+import { noChargeNote } from '../payments/billing-copy.js';
 
 interface MusicGenInput {
   prompt: string;
@@ -101,7 +102,7 @@ function buildExecute(deps: MusicGenDeps) {
     if (contentId && deps.library) {
       const content = deps.library.get(contentId);
       if (!content) {
-        return { output: `Content ${contentId} not found. No USDC was spent.` };
+        return { output: `Content ${contentId} not found. ${noChargeNote()}` };
       }
       if (content.spentUsd + trackCostUsd > content.budgetUsd + 1e-9) {
         return {
@@ -109,7 +110,7 @@ function buildExecute(deps: MusicGenDeps) {
             `## Music generation skipped\n` +
             `- Would exceed budget: spent $${content.spentUsd.toFixed(2)} + fixed ` +
             `$${trackCostUsd.toFixed(2)} > cap $${content.budgetUsd.toFixed(2)}\n\n` +
-            `No USDC was spent.`,
+            noChargeNote(),
         };
       }
     }
@@ -331,7 +332,7 @@ export function createMusicGenCapability(deps: MusicGenDeps = {}): CapabilityHan
       description:
         "Generate a ~3-minute MP3 track from a text prompt (plus optional " +
         "lyrics or instrumental flag). Calls BlockRun's /v1/audio/generations. " +
-        "Costs $0.1575 USDC per call — bills a flat rate, MiniMax ignores " +
+        "Costs $0.1575 per call — bills a flat rate, MiniMax ignores " +
         "duration hints and always returns ~3 min. Generation takes 1–3 " +
         "minutes. ALWAYS confirm with the user before calling — music is " +
         "expensive and slow. Pass contentId to attach to a Content piece " +

--- a/src/tools/phone.ts
+++ b/src/tools/phone.ts
@@ -27,6 +27,7 @@ import { loadChain, VERSION} from '../config.js';
 import { gatewayBase, gatewayHeaders } from '../payments/auth-mode.js';
 import { logger } from '../logger.js';
 import { recordUsage } from '../stats/tracker.js';
+import { chargedNote, noChargeNote, cancelHint } from '../payments/billing-copy.js';
 
 const PHONE_TIMEOUT_MS = 30_000;
 
@@ -173,7 +174,7 @@ export const listPhoneNumbersCapability: CapabilityHandler = {
     description:
       'List the phone numbers your wallet currently owns (US/CA, leased 30 days at a time). ' +
       'Use this before any phone-related action to remind the agent what numbers are available. ' +
-      'Costs $0.001 USDC. Returns each number with country, area code, expiration timestamp, ' +
+      'Costs $0.001 per call. Returns each number with country, area code, expiration timestamp, ' +
       'and current status (active/expiring/expired).',
     input_schema: { type: 'object', properties: {} },
   },
@@ -184,7 +185,7 @@ export const listPhoneNumbersCapability: CapabilityHandler = {
       );
       return {
         output:
-          `## Phone numbers (wallet-owned)\n\n` +
+          `## Phone numbers (provisioned to this account)\n\n` +
           '```json\n' + JSON.stringify(res, null, 2) + '\n```',
       };
     } catch (err) {
@@ -197,7 +198,7 @@ export const buyPhoneNumberCapability: CapabilityHandler = {
   spec: {
     name: 'BuyPhoneNumber',
     description:
-      'Provision a new US or CA phone number for the wallet for 30 days. Costs $5 USDC. ' +
+      'Provision a new US or CA phone number for 30 days. Costs $5.00 per number. ' +
       'Optionally pin a 3-digit area code (best effort). The provisioned number is auto-registered ' +
       'as a valid caller ID for outbound VoiceCall. A wallet can hold multiple numbers; this adds ' +
       'one, never replaces. To pick the country: country="US" (default) or country="CA".',
@@ -219,11 +220,11 @@ export const buyPhoneNumberCapability: CapabilityHandler = {
     const autoApprove = process.env.FRANKLIN_MEDIA_AUTO_APPROVE_ALL === '1';
     if (!autoApprove && ctx.onAskUser) {
       const answer = await ctx.onAskUser(
-        `Buy a new ${body.country || 'US'} phone number for $5.00 USDC? No USDC is spent if you cancel.`,
+        `Buy a new ${body.country || 'US'} phone number for $5.00? ${cancelHint()}`,
         ['Buy', 'Cancel'],
       );
       if (answer !== 'Buy') {
-        return { output: `## Phone number purchase cancelled\n\nNo USDC was spent.` };
+        return { output: `## Phone number purchase cancelled\n\n${noChargeNote()}` };
       }
     }
     try {
@@ -232,7 +233,7 @@ export const buyPhoneNumberCapability: CapabilityHandler = {
       );
       return {
         output:
-          `## Number provisioned ($5 USDC charged)\n\n` +
+          `## Number provisioned (${chargedNote(5)})\n\n` +
           '```json\n' + JSON.stringify(res, null, 2) + '\n```',
       };
     } catch (err) {
@@ -245,7 +246,7 @@ export const renewPhoneNumberCapability: CapabilityHandler = {
   spec: {
     name: 'RenewPhoneNumber',
     description:
-      'Extend the 30-day lease on a wallet-owned phone number. Costs $5 USDC. Use ListPhoneNumbers ' +
+      'Extend the 30-day lease on a BlockRun-provisioned phone number. Costs $5.00. Use ListPhoneNumbers ' +
       'first to confirm the number is yours. Released or expired numbers cannot be renewed — buy a ' +
       'new one with BuyPhoneNumber instead.',
     input_schema: {
@@ -264,11 +265,11 @@ export const renewPhoneNumberCapability: CapabilityHandler = {
     const autoApprove = process.env.FRANKLIN_MEDIA_AUTO_APPROVE_ALL === '1';
     if (!autoApprove && ctx.onAskUser) {
       const answer = await ctx.onAskUser(
-        `Renew ${input.phone_number} for 30 days at $5.00 USDC? No USDC is spent if you cancel.`,
+        `Renew ${input.phone_number} for 30 days at $5.00? ${cancelHint()}`,
         ['Renew', 'Cancel'],
       );
       if (answer !== 'Renew') {
-        return { output: `## Renewal cancelled\n\nNo USDC was spent.` };
+        return { output: `## Renewal cancelled\n\n${noChargeNote()}` };
       }
     }
     try {
@@ -280,7 +281,7 @@ export const renewPhoneNumberCapability: CapabilityHandler = {
       );
       return {
         output:
-          `## Lease renewed (+30 days, $5 USDC charged)\n\n` +
+          `## Lease renewed (+30 days, ${chargedNote(5)})\n\n` +
           '```json\n' + JSON.stringify(res, null, 2) + '\n```',
       };
     } catch (err) {
@@ -293,7 +294,7 @@ export const releasePhoneNumberCapability: CapabilityHandler = {
   spec: {
     name: 'ReleasePhoneNumber',
     description:
-      'Release a wallet-owned phone number back to the BlockRun pool before its lease expires. ' +
+      'Release a BlockRun-provisioned phone number back to the pool before its lease expires. ' +
       'Free. The number is gone after this — it may be picked up by another wallet. Use when you ' +
       "no longer need a test number and want it out of your ListPhoneNumbers result.",
     input_schema: {
@@ -331,8 +332,8 @@ export const phoneLookupCapability: CapabilityHandler = {
     name: 'PhoneLookup',
     description:
       'Look up carrier and line type information for ANY phone number (does not need to be ' +
-      'wallet-owned). Returns carrier name, line type (mobile/landline/voip), country, and ' +
-      'portability info. Costs $0.01 USDC. Use to validate a number before texting/calling or ' +
+      'BlockRun-provisioned). Returns carrier name, line type (mobile/landline/voip), country, and ' +
+      'portability info. Costs $0.01 per lookup. Use to validate a number before texting/calling or ' +
       'to figure out whether a contact number is a real mobile.',
     input_schema: {
       type: 'object',
@@ -355,7 +356,7 @@ export const phoneLookupCapability: CapabilityHandler = {
       );
       return {
         output:
-          `## Phone lookup ($0.01 USDC charged)\n\n` +
+          `## Phone lookup (${chargedNote(0.01)})\n\n` +
           '```json\n' + JSON.stringify(res, null, 2) + '\n```',
       };
     } catch (err) {
@@ -392,7 +393,7 @@ export const phoneFraudCheckCapability: CapabilityHandler = {
       );
       return {
         output:
-          `## Fraud check ($0.05 USDC charged)\n\n` +
+          `## Fraud check (${chargedNote(0.05)})\n\n` +
           '```json\n' + JSON.stringify(res, null, 2) + '\n```',
       };
     } catch (err) {

--- a/src/tools/prediction.ts
+++ b/src/tools/prediction.ts
@@ -54,6 +54,7 @@ import { logger } from '../logger.js';
 import { recordFetch } from '../trading/providers/telemetry.js';
 import { recordUsage } from '../stats/tracker.js';
 import { frameUntrusted } from './untrusted.js';
+import { receiptLine } from '../payments/billing-copy.js';
 
 const TIMEOUT_MS = 30_000;
 const DEFAULT_LIMIT = 20;
@@ -527,7 +528,7 @@ async function execute(input: Record<string, unknown>, ctx: ExecutionScope): Pro
             lines.push(`${i + 1}. **[${platform}]** ${title}`);
           });
         }
-        lines.push(`_$0.005 paid via x402._`);
+        lines.push(receiptLine(0.005));
         return { output: frameUntrusted('Prediction-market data (untrusted)', lines.join('\n')) };
       }
 
@@ -573,7 +574,7 @@ async function execute(input: Record<string, unknown>, ctx: ExecutionScope): Pro
           if (winRate != null) parts.push(`win ${formatPct(winRate as number, 0)}`);
           lines.push(`${i + 1}. \`${w}\`${handle}` + (parts.length > 0 ? ` — ${parts.join(' · ')}` : ''));
         });
-        lines.push('', `_$0.001 paid via x402._`);
+        lines.push('', receiptLine(0.001));
         return { output: frameUntrusted('Prediction-market data (untrusted)', lines.join('\n')) };
       }
 
@@ -684,7 +685,7 @@ async function execute(input: Record<string, unknown>, ctx: ExecutionScope): Pro
           }
           if (recent.length > 0) lines.push(`   ${recent.join(' · ')}`);
         });
-        lines.push('', `_$0.005 paid via x402._`);
+        lines.push('', receiptLine(0.005));
         return { output: frameUntrusted('Prediction-market data (untrusted)', lines.join('\n')) };
       }
 
@@ -760,7 +761,7 @@ async function execute(input: Record<string, unknown>, ctx: ExecutionScope): Pro
             });
           }
         }
-        lines.push('', `_$0.005 paid via x402._`);
+        lines.push('', receiptLine(0.005));
         return { output: frameUntrusted('Prediction-market data (untrusted)', lines.join('\n')) };
       }
 
@@ -829,7 +830,7 @@ async function execute(input: Record<string, unknown>, ctx: ExecutionScope): Pro
           }
           lines.push(`${i + 1}. **${title}** — ${parts.join(' · ')}`);
         });
-        lines.push('', `_$0.005 paid via x402._`);
+        lines.push('', receiptLine(0.005));
         return { output: frameUntrusted('Prediction-market data (untrusted)', lines.join('\n')) };
       }
 
@@ -868,7 +869,7 @@ async function execute(input: Record<string, unknown>, ctx: ExecutionScope): Pro
           if (netBuyersPct != null) stats.push(`${formatPct(netBuyersPct as number, 0)} net buyers`);
           lines.push(`${i + 1}. **${title}**${cidTag}` + (stats.length > 0 ? `\n   ${stats.join(' · ')}` : ''));
         });
-        lines.push('', `_$0.005 paid via x402._`);
+        lines.push('', receiptLine(0.005));
         return { output: frameUntrusted('Prediction-market data (untrusted)', lines.join('\n')) };
       }
 
@@ -912,7 +913,7 @@ async function execute(input: Record<string, unknown>, ctx: ExecutionScope): Pro
           if (pos.avg_smart_win_rate != null) perf.push(`win ${formatPct(pos.avg_smart_win_rate, 0)}`);
           lines.push(`**Smart performance:** ${perf.join(' · ')}`);
         }
-        lines.push('', `_$0.005 paid via x402._`);
+        lines.push('', receiptLine(0.005));
         return { output: frameUntrusted('Prediction-market data (untrusted)', lines.join('\n')) };
       }
 
@@ -960,7 +961,7 @@ async function execute(input: Record<string, unknown>, ctx: ExecutionScope): Pro
             (end ? ` · ends ${String(end).slice(0, 10)}` : '')
           );
         });
-        lines.push('', `_$0.001 paid via x402._`);
+        lines.push('', receiptLine(0.001));
         return { output: frameUntrusted('Prediction-market data (untrusted)', lines.join('\n')) };
       }
 
@@ -998,7 +999,7 @@ async function execute(input: Record<string, unknown>, ctx: ExecutionScope): Pro
             (m.close_time ? ` · closes ${String(m.close_time).slice(0, 10)}` : '')
           );
         });
-        lines.push('', `_$0.001 paid via x402._`);
+        lines.push('', receiptLine(0.001));
         return { output: frameUntrusted('Prediction-market data (untrusted)', lines.join('\n')) };
       }
 

--- a/src/tools/videogen.ts
+++ b/src/tools/videogen.ts
@@ -41,6 +41,7 @@ import { resolveReferenceImage } from './imagegen.js';
 import { isWalletKeyPath } from './sensitive-paths.js';
 import { recordUsage } from '../stats/tracker.js';
 import { findModel, estimateCostUsd, GATEWAY_MARGIN, type GatewayModel } from '../gateway-models.js';
+import { noChargeNote, cancelHint } from '../payments/billing-copy.js';
 
 interface VideoGenInput {
   prompt: string;
@@ -181,11 +182,11 @@ function buildExecute(deps: VideoGenDeps) {
       // the prompt (flat per-second fallback only when the model is unknown).
       const est = resolveVideoUnitCost(videoCatalogModel, duration);
       const answer = await ctx.onAskUser(
-        `Generate a ${duration}s video with ${videoModel} for ~$${est.toFixed(2)}? No USDC is spent if you cancel.`,
+        `Generate a ${duration}s video with ${videoModel} for ~$${est.toFixed(2)}? ${cancelHint()}`,
         ['Generate', 'Cancel'],
       );
       if (answer !== 'Generate') {
-        return { output: `## Video generation cancelled\n\nNo USDC was spent.` };
+        return { output: `## Video generation cancelled\n\n${noChargeNote()}` };
       }
     }
 
@@ -194,7 +195,7 @@ function buildExecute(deps: VideoGenDeps) {
     if (contentId && deps.library) {
       const content = deps.library.get(contentId);
       if (!content) {
-        return { output: `Content ${contentId} not found. No USDC was spent.` };
+        return { output: `Content ${contentId} not found. ${noChargeNote()}` };
       }
       if (content.spentUsd + estCost > content.budgetUsd + 1e-9) {
         return {
@@ -202,7 +203,7 @@ function buildExecute(deps: VideoGenDeps) {
             `## Video generation skipped\n` +
             `- Would exceed budget: spent $${content.spentUsd.toFixed(2)} + estimated ` +
             `$${estCost.toFixed(2)} > cap $${content.budgetUsd.toFixed(2)}\n\n` +
-            `No USDC was spent.`,
+            noChargeNote(),
         };
       }
     }
@@ -588,7 +589,7 @@ export function createVideoGenCapability(deps: VideoGenDeps = {}): CapabilityHan
       name: 'VideoGen',
       description:
         "Generate a short MP4 video from a text prompt (optional seed image). " +
-        "Calls BlockRun's /v1/videos/generations. Costs USDC — default model " +
+        "Calls BlockRun's /v1/videos/generations. Billed per generation — default model " +
         "xai/grok-imagine-video bills $0.05/s (8s default ≈ $0.42). Generation " +
         "takes ~20–60s. ALWAYS confirm with the user before calling — videos " +
         "are expensive and slow. Pass contentId to attach to a Content piece " +

--- a/src/tools/voice.ts
+++ b/src/tools/voice.ts
@@ -7,7 +7,7 @@
  *  - VoiceStatus — GET  /v1/voice/call/{call_id} (free). Polls for transcript
  *                  + recording + final disposition.
  *
- * Voice calls require a wallet-owned BlockRun phone number as caller ID —
+ * Voice calls require a BlockRun-provisioned phone number as caller ID —
  * use BuyPhoneNumber (or ListPhoneNumbers if one already exists) before
  * calling VoiceCall, otherwise the gateway returns 400 with the buy
  * instructions inline.
@@ -32,6 +32,7 @@ import { logger } from '../logger.js';
 import { recordUsage } from '../stats/tracker.js';
 import { frameUntrusted } from './untrusted.js';
 import { CallLog, type CallStatus } from '../phone/call-log.js';
+import { chargedNote } from '../payments/billing-copy.js';
 
 /** Singleton, lazy — paths are computed at first use so tests can stub homedir. */
 let _callLog: CallLog | null = null;
@@ -260,7 +261,7 @@ export const voiceCallCapability: CapabilityHandler = {
       'Common use cases: appointment reminders, verification callbacks, voice surveys, customer ' +
       'outreach, OTP retrieval, two-party verification calls.\n\n' +
       'Requirements:\n' +
-      '  - `from` MUST be a wallet-owned BlockRun phone number — use ListPhoneNumbers to find ' +
+      '  - `from` MUST be a BlockRun-provisioned phone number — use ListPhoneNumbers to find ' +
       'one or BuyPhoneNumber to provision one ($5, 30-day lease).\n' +
       '  - `to` and `from` must be E.164 format (+ country code prefix, e.g. +14155552671).\n' +
       '  - `task` must be ≥10 chars, ≤4000 chars.\n' +
@@ -342,7 +343,7 @@ export const voiceCallCapability: CapabilityHandler = {
   },
   execute: async (input, ctx): Promise<CapabilityResult> => {
     if (typeof input.to !== 'string') return { output: 'to (E.164) required', isError: true };
-    if (typeof input.from !== 'string') return { output: 'from (wallet-owned E.164) required — use ListPhoneNumbers / BuyPhoneNumber', isError: true };
+    if (typeof input.from !== 'string') return { output: 'from (BlockRun-provisioned E.164) required — use ListPhoneNumbers / BuyPhoneNumber', isError: true };
     if (typeof input.task !== 'string' || input.task.length < 10) {
       return { output: 'task required (10–4000 chars natural-language description)', isError: true };
     }
@@ -386,7 +387,7 @@ export const voiceCallCapability: CapabilityHandler = {
       } catch { /* best-effort */ }
       return {
         output:
-          `## Voice call initiated ($0.54 USDC charged)\n\n` +
+          `## Voice call initiated (${chargedNote(0.54)})\n\n` +
           `**call_id:** \`${callId}\`\n\nPoll with VoiceStatus call_id="${callId}" to get the ` +
           `transcript and disposition. The call typically completes in 1–6 minutes.\n\n` +
           '```json\n' + JSON.stringify(res, null, 2) + '\n```',

--- a/test/api-key.local.mjs
+++ b/test/api-key.local.mjs
@@ -649,6 +649,68 @@ test('the system prompt does not promise a wallet in key mode', async () => {
   assert.match(keyPrompt, /Don't hesitate on cents/);
 });
 
+// ── Billing copy ──────────────────────────────────────────────────────────
+// These strings are the receipt the user reads, the prompt they approve, and
+// the text the model reasons over when deciding what it can afford.
+
+test('billing copy names the instrument that actually paid', async () => {
+  const copy = await import('../dist/payments/billing-copy.js');
+
+  clean();
+  auth.resetPayModeCache();
+  assert.match(copy.chargedNote(5), /\$5\.00 USDC charged/);
+  assert.match(copy.noChargeNote(), /No USDC was spent/);
+  assert.match(copy.cancelHint(), /No USDC is spent if you cancel/);
+  assert.match(copy.receiptLine(0.005), /\$0\.0050 paid via x402/);
+
+  process.env.BLOCKRUN_API_KEY = VALID_KEY;
+  auth.resetPayModeCache();
+  for (const s of [copy.chargedNote(5), copy.noChargeNote(), copy.cancelHint(), copy.receiptLine(0.005)]) {
+    assert.doesNotMatch(s, /USDC/, `key mode must not say USDC: ${s}`);
+    assert.doesNotMatch(s, /x402/, `key mode must not say x402: ${s}`);
+  }
+  assert.match(copy.chargedNote(5), /account credits/);
+  // Key mode states no amount on a receipt: the local figure is an estimate
+  // and the account ledger is authoritative.
+  assert.doesNotMatch(copy.chargedNote(5), /\$5/, 'no local amount presented as the charge');
+  // Sub-cent tiers must not render as $0.00 in wallet mode.
+  clean();
+  auth.resetPayModeCache();
+  assert.match(copy.receiptLine(0.001), /\$0\.0010/);
+  clean();
+});
+
+test('the mode is read at call time, not captured at import', async () => {
+  // invalidateKey() demotes a session to wallet mode mid-run after a 401.
+  // A helper that memoised the mode would keep printing "account credits"
+  // while Franklin was signing from the wallet again.
+  const { chargedNote } = await import('../dist/payments/billing-copy.js');
+  clean();
+  process.env.BLOCKRUN_API_KEY = VALID_KEY;
+  auth.resetPayModeCache();
+  assert.match(chargedNote(1), /account credits/);
+  auth.invalidateKey();
+  assert.match(chargedNote(1), /USDC charged/, 'demotion must change the copy immediately');
+  clean();
+});
+
+test('no paid tool states a payment rail unconditionally', async () => {
+  // Regression fence for the whole class. Every one of these was a live
+  // string that fired in key mode before this change.
+  const files = ['phone', 'prediction', 'videogen', 'imagegen', 'musicgen', 'voice', 'modal', 'blockrun', 'surf', 'realface', 'exa', 'rpc', 'defillama'];
+  const offenders = [];
+  for (const f of files) {
+    const src = await readFile(new URL(`../src/tools/${f}.ts`, import.meta.url), 'utf-8');
+    src.split('\n').forEach((line, i) => {
+      if (/paid via x402|USDC charged|No USDC (is|was) spent|USDC from the user's wallet|wallet-owned/.test(line)) {
+        offenders.push(`src/tools/${f}.ts:${i + 1}: ${line.trim().slice(0, 90)}`);
+      }
+    });
+  }
+  assert.deepEqual(offenders, [],
+    `use the billing-copy helpers (or mode-neutral wording in static spec text):\n${offenders.join('\n')}`);
+});
+
 test('cleanup', () => {
   clean();
   rmSync(TEST_HOME, { recursive: true, force: true });


### PR DESCRIPTION
Follow-up to #162 (merged). Verified against `main`, not against the closed #156.

## The problem

Six paid tool files have **zero** key-mode awareness and state the wrong payment instrument in 38 places.

| file | sites | `isKeyMode` refs before |
|---|---|---|
| `phone.ts` | 15 | 0 |
| `prediction.ts` | 9 | 0 |
| `videogen.ts` | 5 | 0 |
| `imagegen.ts` | 4 | 0 |
| `voice.ts` | 4 | 0 |
| `musicgen.ts` | 3 | 0 |
| `modal.ts`, `blockrun.ts` | 2 | — |

```
PredictionMarket  →  _$0.005 paid via x402._                  (signed nothing)
BuyPhoneNumber    →  ## Number provisioned ($5 USDC charged)  (wallet never moved)
```

The worst of the set are the **approval prompts** in ImageGen / VideoGen / phone. The human is asked to approve a spend in a currency the session does not use, and the model reads the same wrong sentence when it reasons about what it can still afford.

## Before / after

```
[wallet mode]                                    [key mode]
## Number provisioned ($5.00 USDC charged)       ## Number provisioned (billed to account
                                                    credits — see Activity at user.blockrun.ai)
Buy a new US number for $5.00?                   Buy a new US number for $5.00?
  No USDC is spent if you cancel.                  No account credits are spent if you cancel.
_$0.0050 paid via x402._                         _Billed to account credits._
```

## The split that matters

**Runtime output** (receipts, prompts, cancellations) calls the new `src/payments/billing-copy.ts` helpers, which read the mode **at call time**. `invalidateKey()` demotes a session mid-run after a 401 — a helper that captured the mode at import would keep claiming account credits while Franklin signed from the wallet again. There is a test for exactly that.

**Static `spec.description`** is built once at module load, before any mode is settled, and cannot re-render. Branching there would freeze whichever mode resolved first, so those strings are reworded to be true in *both*: `Costs $0.001 per call`, not `Costs $0.001 USDC from the wallet`. Likewise `wallet-owned phone number` → `BlockRun-provisioned`.

Key mode deliberately states **no dollar amount** on a receipt. The local figure is a catalog estimate; the account ledger is authoritative, so it points at Activity rather than inventing precision.

## Verification

A regression fence scans every paid tool for an unconditional payment-rail string and names the offending `file:line`, so the next tool cannot reintroduce the class.

Mutation-tested — each fails a named test:

| mutation | result |
|---|---|
| revert one `phone.ts` call site | fails the regression fence |
| make `chargedNote` ignore the mode | 2 fail |
| memoise the mode at import | 2 fail |

**730 local tests pass.**

## Credit

`phone.ts` had 5 of these fixed in #156 before it was closed as superseded; that approach is carried forward here and extended to the other six files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rm7cRGtC7wCofhYuHRo21h