### PR TITLE
docs: account billing is a shipped path, so stop saying there is no account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## Franklin Agent 3.46.0 — the account key could be read out of the agent, and key mode kept talking about a wallet
+
+**The account key was one auto-approved command away from your transcript.**
+Key mode puts a bearer credential in the environment, and the Bash tool handed
+the whole environment to every subprocess. `printenv` and `echo` are classified
+safe, so `printenv BLOCKRUN_API_KEY` needed no confirmation and returned the key
+as tool output — into the model prompt, over the network to whichever gateway
+model served the turn, and into the saved session. `cat ~/.blockrun/api-key`
+reached the same place through Read, because only the wallet key files were
+guarded.
+
+The redactor already knew the `brk_` shape. It never saw this: its one call site
+scrubs what *you* type, not what a tool returns. The key is not a private key,
+but it spends — a prepaid balance, no per-call signature, no chain-level ceiling
+— so it now gets the containment the wallet keys always had. It is withheld from
+the Bash subprocess, the key file is guarded like `.session`, and every tool
+result is scrubbed at the one funnel they all pass through, before the
+persist-to-disk branch so an oversized result is not written out in the clear.
+
+**An account error is no longer permission to spend from your wallet.** A 401 or
+a 404 used to replay the request against the wallet gateway, and a 401 switched
+the rest of the process to wallet billing. That silently changes who pays.
+Account errors now surface as themselves; `--wallet` is how you choose the other
+rail. An invalid, empty or unreadable key stops with an actionable error instead
+of quietly picking a different payment method.
+
+**Franklin stopped claiming USDC moved when it did not.** Six paid tools had no
+idea key mode existed and stated the wrong instrument in 38 places —
+`_$0.005 paid via x402._` on a call that signed nothing, `$5 USDC charged`
+against a wallet that never moved. The worst were the image, video and phone
+approval prompts, which asked you to approve a spend in a currency your session
+does not use. Receipts and prompts now name the rail that actually paid, and
+key-mode receipts state no dollar amount at all: the local figure is an estimate
+and your account ledger is authoritative, so they point at Activity instead of
+inventing precision.
+
+**Modal was unusable on an account.** The sandbox tools gated on an on-chain
+balance, so an unfunded wallet read $0 and every call failed with "fund the
+wallet" while account credits sat there. They read the credit balance now, and
+an ungated account or an unreachable gateway means no local ceiling rather than
+an invented one.
+
+**The system prompt no longer promises a wallet that isn't there.** Key-mode
+sessions were briefed on a chain, an address and a USDC balance, and pointed at
+a Wallet tool that returns a portal link. The instruction cache is keyed on the
+pay mode too, so a session that switches rails mid-run cannot be served the
+stale briefing.
+
 ## Franklin Agent 3.45.0 — the gateway now says what it charged, and the price the agent read was wrong
 
 **Paid calls are booked exactly instead of estimated.** The BlockRun gateway

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,9 @@
 
 **The AI agent with a wallet.**
 
-Franklin is a **general autonomous economic agent** — it doesn't just write text, it autonomously spends USDC from a user-funded wallet to execute real work — with **trading as the flagship vertical**. It is explicitly NOT positioned as a coding agent (decided 2026-07-17): file/shell tools are kept as general infrastructure (strategy scripts, data analysis) but faded from positioning, docs, and the default experience.
+_Billing has two rails as of 3.44.0: a USDC wallet (x402) or a prepaid BlockRun account key. Wallet is the identity and the story; the key is the on-ramp for people who would rather top up a balance. On-chain actions always need the wallet._
+
+Franklin is a **general autonomous economic agent** — it doesn't just write text, it autonomously spends real money (USDC from a user-funded wallet, or prepaid account credits) to execute real work — with **trading as the flagship vertical**. It is explicitly NOT positioned as a coding agent (decided 2026-07-17): file/shell tools are kept as general infrastructure (strategy scripts, data analysis) but faded from positioning, docs, and the default experience.
 
 Capability pillars:
 - **Trading agent (flagship)** — signals, portfolio, risk, trade-plan approvals, wallet-keyed journal, persistent P&L
@@ -72,6 +74,7 @@ src/
 | Layer | Message | Audience |
 |-------|---------|----------|
 | External (X, YouTube, KOL) | **The AI Agent with a Wallet** — it holds your USDC and actually spends it for you | Everyone |
+| Onboarding | **Or just top up an account** — `franklin login brk_...` for people not ready to fund a wallet | Newcomers |
 | Core users / docs | **Autonomous Economic Agent** powered by x402 payment layer | Crypto AI community, power users |
 | Product direction | **Trading flagship + general autonomy** — mission-control fleet, one agent per strategy/market | Power users |
 
@@ -84,5 +87,5 @@ The moat is the payment layer plus the safety architecture around autonomous spe
 
 **What sets Franklin apart:**
 - Most agents can think but can't spend; the ones that spend have no guardrails
-- Franklin: you fund the wallet and set the budget; it proposes, you approve, it executes and journals every trade
+- Franklin: you fund it (wallet or account credits) and set the budget; it proposes, you approve, it executes and journals every trade
 - Memory follows the wallet, goals survive sessions, and the whole fleet is visible in one panel

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -7,7 +7,7 @@ reviewed Franklin runtime and the matching UI.
 ## Current beta
 
 - Franklin chat with streaming tool activity and inline permission requests
-- local Base and Solana wallets with in-app network switching
+- local Base and Solana wallets with in-app network switching, or prepaid account billing via a BlockRun API key
 - model catalog, skills, MCP, media generation, wallet activity, and market tools
 - Agent Studio for discovering and importing supported local agent runtimes
 - personal and Team conversation spaces

--- a/docs/subscription-ai-is-dead.md
+++ b/docs/subscription-ai-is-dead.md
@@ -90,9 +90,11 @@ The model that wins looks like this:
 - **Smart routers** pick the best provider per task from a
   cross-vendor pool, and the wallet doesn't know or care who
   answered.
-- **The wallet is identity.** There is no account, no KYC, no email,
-  no phone. The public address that signed the last micropayment is
-  the user.
+- **The wallet is identity.** No KYC, no email, no phone. The public
+  address that signed the last micropayment is the user. (Franklin
+  also accepts a prepaid account key for people who would rather top
+  up a balance — the same per-call pricing, a different on-ramp. The
+  wallet path is the one that needs no account at all.)
 
 The technical label for this is **x402 micropayments**. The business
 label is **YOPO — You Only Pay Outcome**. The product-category label
@@ -147,7 +149,8 @@ franklin
 ```
 
 Free-tier models run at $0.00. Funded models run at market rates.
-Either way, no subscription, no API key, no account.
+Either way, no subscription — and on the wallet path, no API key and
+no account either.
 
 That is what the next decade of AI pricing looks like. It is already
 shipping.

--- a/docs/why-ai-agents-need-a-wallet.md
+++ b/docs/why-ai-agents-need-a-wallet.md
@@ -189,7 +189,12 @@ franklin                 # start — free NVIDIA models by default
 Top up the wallet with $5 of USDC and every frontier model is
 reachable. Top up with $0 and Franklin still runs — on free tier
 models. There is no subscription. There is no rate limit that isn't
-the wallet itself. There is no tier. There is no account.
+the wallet itself. There is no tier, and on this path, no account.
+
+(If you would rather not hold USDC, `franklin login` takes a prepaid
+account key instead. Same per-call pricing, same free tier; you trade
+the account-free property for a card. On-chain actions still need the
+wallet.)
 
 Franklin is the smallest honest move: *if an agent is going to act
 with autonomy, give it something it can lose.* A wallet. Not trust.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockrun/franklin",
-  "version": "3.45.0",
+  "version": "3.46.0",
   "description": "Franklin Agent — The AI agent with a wallet. Spends USDC autonomously to get real work done. Pay per action, no subscriptions.",
   "type": "module",
   "exports": {


### PR DESCRIPTION
Two published posts still tell readers the product has no accounts and no API keys. That has been false since 3.44.0.

| file | was |
|---|---|
| `docs/subscription-ai-is-dead.md:93` | "There is no account, no KYC, no email, no phone" |
| `docs/subscription-ai-is-dead.md:150` | "no subscription, no API key, no account" |
| `docs/why-ai-agents-need-a-wallet.md:192` | "There is no tier. There is no account." |
| `CLAUDE.md` | wallet-only throughout |
| `apps/desktop/README.md:10` | wallet-only |

**The essays keep their argument.** "The wallet is identity" is still the thesis and still true of the wallet path — it is now one of two rails, so the absolute claims are qualified rather than deleted. Someone reading them to decide whether Franklin needs a signup should get the right answer.

`CLAUDE.md` gains the rail split up front and an onboarding row in the positioning table. Wallet stays the identity and the story; the key is the on-ramp for people not ready to hold USDC; on-chain actions still require the wallet.

`CHANGELOG` 3.46.0 covers #162, #163, #158, #164. Version bumped to 3.46.0.

**Not changed, because they were already correct on main:** the README "Two ways to pay" section and its nav, and the 3.44.0 / 3.45.0 changelog entries. An earlier pass called those stale from a review of the superseded #156 branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rm7cRGtC7wCofhYuHRo21h