### PR TITLE
chore(brand): refresh the snapshot — the markers were rendering a stale catalog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Franklin Agent
 
-Open-source AI agent with a wallet. <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models. Pay per use with BlockRun API account credit or USDC wallets via x402.
+Open-source AI agent with a wallet. <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> models. Pay per use with BlockRun API account credit or USDC wallets via x402.
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Capability pillars:
 
 Built on three layers:
 1. **x402 micropayment protocol** — HTTP 402 native payments
-2. **BlockRun Gateway** — aggregates <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> LLMs + paid APIs (Exa, DALL-E, future Runway/Suno/CoinGecko)
+2. **BlockRun Gateway** — aggregates <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> LLMs + paid APIs (Exa, DALL-E, future Runway/Suno/CoinGecko)
 3. **Franklin Agent** — this repo, the reference client
 
 ## Commands

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -19,7 +19,7 @@ The first, unpaid HTTP request whose 402 response carries the payment terms; Fra
 _Avoid_: Pre-flight, handshake.
 
 **BlockRun Gateway**:
-The single upstream service Franklin calls for both LLM completions and paid tools (Exa, ImageGen, VideoGen, MusicGen, market data); aggregates <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models and accepts x402.
+The single upstream service Franklin calls for both LLM completions and paid tools (Exa, ImageGen, VideoGen, MusicGen, market data); aggregates <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> models and accepts x402.
 _Avoid_: API, provider, backend, BlockRun (without "Gateway") when referring to the service.
 
 **Per-turn spend cap**:

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ Every tool call is itemized. Every token is priced. When the wallet hits zero, F
 
 ## Smart Router
 
-**<!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models. One decision. Zero guesswork.**
+**<!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> models. One decision. Zero guesswork.**
 
 You don't pick models. Franklin picks for you.
 
@@ -463,7 +463,7 @@ No email. No phone. No KYC. Your Solana or Base address is your account — port
 | Writes code                            | ✅               | ✅               | ⚠️                | ✅                              |
 | **Spends money for you**               | ❌               | ❌               | ❌               | ✅ **USDC wallet, x402**        |
 | **Buys data + APIs + images + search** | ❌               | ❌               | ❌               | ✅ **55+ APIs, one wallet**     |
-| Picks best model per task              | ❌ single-vendor | ❌ plan-tied    | ❌               | ✅ **Smart Router, <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models** |
+| Picks best model per task              | ❌ single-vendor | ❌ plan-tied    | ❌               | ✅ **Smart Router, <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> models** |
 | Pricing model                          | Subscription     | Subscription     | Subscription     | **YOPO** — per outcome, USDC    |
 | Monthly fee                            | $20–$200         | $20–$40          | $20+             | **$0**                          |
 | Rate-limited                           | Yes              | Yes              | Yes              | No — limited only by wallet     |
@@ -491,14 +491,14 @@ Ask "what's BTC looking like?" — Franklin fetches live price data, computes RS
 **🎨 AI image generation**
 Ask "generate a logo" — Franklin calls DALL-E / GPT Image, saves the result locally, paid from your wallet.
 
-**🧠 <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models via one wallet**
+**🧠 <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> models via one wallet**
 Anthropic, OpenAI, Google, xAI, DeepSeek, GLM, Kimi, Minimax, NVIDIA free tier. One wallet, one interface, automatic fallback.
 
 **💳 x402 micropayments (YOPO)**
 HTTP 402 native. Every paid action is a signed USDC micropayment via EIP-712 — non-custodial, your keys never leave your machine. YOPO: you pay only for outcomes.
 
 **🧠 Learned model router**
-Trained on 2M+ real requests. Classifies your task and picks the best model from <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> LLMs. Four profiles (auto/eco/premium/free). Adapts to your usage over time.
+Trained on 2M+ real requests. Classifies your task and picks the best model from <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> LLMs. Four profiles (auto/eco/premium/free). Adapts to your usage over time.
 
 </td>
 <td width="50%" valign="top">
@@ -554,13 +554,13 @@ Core is workflow-agnostic. Add new verticals without touching the loop. Discover
 │  Intent → Smart Router → Tool Use → Spend Control → Result   │
 ├──────────────────────────────────────────────────────────────┤
 │  Learned Router                                              │
-│  2M+ requests · <!-- br:models.chatVisible@live -->76<!-- /br:models.chatVisible@live --> models · category detection · Elo scores │
+│  2M+ requests · <!-- br:models.chatVisible@live -->78<!-- /br:models.chatVisible@live --> models · category detection · Elo scores │
 ├──────────────────────────────────────────────────────────────┤
 │  Agent Loop                                                  │
 │  16 tools · Sessions · Compaction · Pricing · Plugin SDK     │
 ├──────────────────────────────────────────────────────────────┤
 │  BlockRun Gateway                                            │
-│  <!-- br:models.chatVisible@live -->76<!-- /br:models.chatVisible@live --> LLMs · CoinGecko · Search · Image APIs · paid services  │
+│  <!-- br:models.chatVisible@live -->78<!-- /br:models.chatVisible@live --> LLMs · CoinGecko · Search · Image APIs · paid services  │
 ├──────────────────────────────────────────────────────────────┤
 │  x402 Micropayment Protocol                                  │
 │  HTTP 402 · USDC on Solana & Base · signed payment payloads  │
@@ -604,7 +604,7 @@ src/
 ├── stats/             Usage tracking + insights engine
 ├── ui/                Ink-based terminal UI
 ├── proxy/             Payment proxy for external tools
-├── router/            Learned model router (<!-- br:models.chatVisible@live -->76<!-- /br:models.chatVisible@live --> models, Elo scoring)
+├── router/            Learned model router (<!-- br:models.chatVisible@live -->78<!-- /br:models.chatVisible@live --> models, Elo scoring)
 ├── wallet/            Wallet management (Base + Solana)
 ├── mcp/               MCP server auto-discovery
 └── commands/          CLI subcommands

--- a/brand-numbers.json
+++ b/brand-numbers.json
@@ -2,17 +2,17 @@
   "$schema": "https://blockrun.ai/brand/numbers.schema.json",
   "version": 1,
   "models": {
-    "chatVisible": 76,
-    "totalVisible": 100,
-    "free": 7,
-    "freeWithheld": 26,
+    "chatVisible": 78,
+    "totalVisible": 102,
+    "free": 6,
+    "freeWithheld": 27,
     "image": 9,
     "video": 8,
     "music": 1,
     "speech": 5,
     "soundfx": 1,
-    "withFallback": 34,
-    "withFallbackAllEntries": 73
+    "withFallback": 33,
+    "withFallbackAllEntries": 74
   },
   "clawrouter": {
     "dimensions": 15,

--- a/docs/adr/0002-blockrun-gateway-as-aggregator.md
+++ b/docs/adr/0002-blockrun-gateway-as-aggregator.md
@@ -2,7 +2,7 @@
 
 **Status:** accepted
 
-Franklin makes every LLM and paid-tool call through a single counterparty — the BlockRun Gateway — instead of integrating directly with each model provider, image/video/audio service, search API, and market-data feed. The gateway aggregates <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models and a small set of paid APIs and accepts x402 uniformly.
+Franklin makes every LLM and paid-tool call through a single counterparty — the BlockRun Gateway — instead of integrating directly with each model provider, image/video/audio service, search API, and market-data feed. The gateway aggregates <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> models and a small set of paid APIs and accepts x402 uniformly.
 
 ## Considered options
 

--- a/docs/anatomy-of-an-economic-agent.md
+++ b/docs/anatomy-of-an-economic-agent.md
@@ -326,7 +326,7 @@ seamlessly.
                              │ signed USDC (HTTP 402)
                              ▼
                       BlockRun Gateway
-                 <!-- br:models.chatVisible@live -->76<!-- /br:models.chatVisible@live --> models / paid APIs
+                 <!-- br:models.chatVisible@live -->78<!-- /br:models.chatVisible@live --> models / paid APIs
                              │
                              ▼
                        User Wallet

--- a/docs/why-ai-agents-need-a-wallet.md
+++ b/docs/why-ai-agents-need-a-wallet.md
@@ -154,7 +154,7 @@ cheap models because cheapness is now something the agent can
 agents both learn in real time.
 
 **3. Single-vendor failure becomes a one-command swap.** A router
-with <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models across every major provider can route around any
+with <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> models across every major provider can route around any
 single vendor's bad release. The wallet doesn't know or care which
 model answered — it only pays for the answer that arrived.
 
@@ -175,7 +175,7 @@ filled it.
 
 Franklin is the reference implementation of the Economic Agent. It's
 an AI agent CLI that holds USDC on Base or Solana, routes requests
-across <!-- br:models.chatVisible -->76<!-- /br:models.chatVisible --> models, and settles every paid action in real time via
+across <!-- br:models.chatVisible -->78<!-- /br:models.chatVisible --> models, and settles every paid action in real time via
 the [x402](https://x402.org) HTTP-402 micropayment protocol. It is
 Apache-2.0, written in TypeScript, and ships as one npm package.
 


### PR DESCRIPTION
`brand-numbers.json` in this repo was behind the published artifact, so every `br:` marker here rendered a stale number.

The markers worked correctly — they rendered the input they had. `--check` is offline by design so PR CI stays deterministic, which means it validates against this repo's **own** snapshot; only `--refresh` updates that snapshot.

Opened automatically by [`brand/fanout-brand-numbers.mjs`](https://github.com/BlockRunAI/blockrun/blob/main/brand/fanout-brand-numbers.mjs). Produced by `--refresh`, no hand-edited digits.