### PR TITLE
chore(brand): refresh the snapshot — the markers were rendering a stale catalog

### DIFF
--- a/brand-numbers.json
+++ b/brand-numbers.json
@@ -3,10 +3,10 @@
   "version": 1,
   "models": {
     "chatVisible": 78,
-    "totalVisible": 102,
+    "totalVisible": 103,
     "free": 6,
     "freeWithheld": 27,
-    "image": 9,
+    "image": 10,
     "video": 8,
     "music": 1,
     "speech": 5,
@@ -22,9 +22,9 @@
   },
   "mcp": {
     "tools": 19,
-    "contextTokens": 12900,
-    "contextTokensTrading": 5554,
-    "contextCutPct": 57
+    "contextTokens": 12767,
+    "contextTokensTrading": 5270,
+    "contextCutPct": 59
   },
   "chains": {
     "rpc": 40


### PR DESCRIPTION
`brand-numbers.json` in this repo was behind the published artifact, so every `br:` marker here rendered a stale number.

The markers worked correctly — they rendered the input they had. `--check` is offline by design so PR CI stays deterministic, which means it validates against this repo's **own** snapshot; only `--refresh` updates that snapshot.

Opened automatically by [`brand/fanout-brand-numbers.mjs`](https://github.com/BlockRunAI/blockrun/blob/main/brand/fanout-brand-numbers.mjs). Produced by `--refresh`, no hand-edited digits.